### PR TITLE
constraint nodes

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -23,19 +23,23 @@ DFLAGS.${src} += -std=c99
 
 PROG += jvst
 PROG += test_validation
+PROG += test_constraints
 
 .for src in ${SRC:Msrc/*.c}
 ${BUILD}/bin/jvst: ${BUILD}/${src:R}.o
 .endfor
 
 VALID_SRC += src/validate.c
+VALID_SRC += src/validate_constraints.c
 VALID_SRC += src/validate_testing.c
 VALID_SRC += src/sjp_parser.c
 VALID_SRC += src/sjp_testing.c
 
-VALID_SRC += src/test_validation.c
+# currently each test_*.c is a separate program
+VALID_TESTS_SRC += src/test_validation.c
+VALID_TESTS_SRC += src/test_constraints.c
 
-.for src in ${VALID_SRC}
+.for src in ${VALID_SRC} ${VALID_TESTS_SRC}
 CFLAGS.${src} += -std=c99 -fsanitize=address -Wno-missing-field-initializers -Wno-unused
 DFLAGS.${src} += -std=c99
 .endfor
@@ -49,11 +53,18 @@ DFLAGS.${src} += -I share/git/sjp
 LFLAGS.${prog} += -fsanitize=address
 .endfor
 
-.for src in ${VALID_SRC:Msrc/*.c} ${SRC:Msrc/sjp_lexer.c}
-${BUILD}/bin/test_validation: ${BUILD}/${src:R}.o
+.for test in ${VALID_TESTS_SRC:Msrc/*.c}
+_p = ${BUILD}/bin/${test:T:R}
+${_p}: ${BUILD}/${test:R}.o
+
+.for src in ${VALID_SRC:Msrc/*.c} ${SRC:Msrc/*.c:Nsrc/main.c}
+${_p}: ${BUILD}/${src:R}.o
 .endfor
 
-SRC += ${VALID_SRC}
+# THE_TESTS += ${BUILD}/bin/${t0:R}
+.endfor
+
+SRC += ${VALID_SRC} ${VALID_TESTS_SRC}
 
 .for src in ${SRC:Msrc/*.c}
 CFLAGS.${src} += ${CFLAGS.libre}

--- a/src/Makefile
+++ b/src/Makefile
@@ -29,6 +29,7 @@ PROG += test_constraints
 ${BUILD}/bin/jvst: ${BUILD}/${src:R}.o
 .endfor
 
+VALID_SRC += src/validate_sbuf.c
 VALID_SRC += src/validate.c
 VALID_SRC += src/validate_constraints.c
 VALID_SRC += src/validate_testing.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -57,7 +57,7 @@ LFLAGS.${prog} += -fsanitize=address
 _p = ${BUILD}/bin/${test:T:R}
 ${_p}: ${BUILD}/${test:R}.o
 
-.for src in ${VALID_SRC:Msrc/*.c} ${SRC:Msrc/*.c:Nsrc/main.c}
+.for src in ${VALID_SRC:Msrc/*.c} ${SRC:Msrc/*.c:Nsrc/main.c:Nsrc/parser.c}
 ${_p}: ${BUILD}/${src:R}.o
 .endfor
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,7 +17,7 @@ DFLAGS.${src} += -I share/git/sjp
 .endfor
 
 .for src in ${SRC:Msrc/ast.c} ${SRC:Msrc/sjp_lexer.c} ${SRC:Msrc/parser.c} ${SRC:Msrc/main.c}
-CFLAGS.${src} += -std=c99
+CFLAGS.${src} += -std=c99 -Wno-missing-field-initializers
 DFLAGS.${src} += -std=c99
 .endfor
 

--- a/src/test_constraints.c
+++ b/src/test_constraints.c
@@ -901,13 +901,17 @@ static void test_simplify_ands(void)
   const struct cnode_test tests[] = {
     // handle AND with only one level...
     {
-      OPTIMIZE, NULL,
+      OPTIMIZE,
+
+      NULL,
+
       newcnode_switch(&A, 1,
           SJP_NUMBER, newcnode_bool(&A, JVST_CNODE_AND,
                         newcnode_range(&A, JVST_CNODE_RANGE_MIN, 1.1, 0.0),
                         newcnode_valid(),
                         NULL),
           SJP_NONE),
+
       newcnode_switch(&A, 1,
           SJP_NUMBER, newcnode_range(&A, JVST_CNODE_RANGE_MIN, 1.1, 0.0),
           SJP_NONE),
@@ -915,7 +919,10 @@ static void test_simplify_ands(void)
 
     // handle nested ANDs
     {
-      OPTIMIZE, NULL,
+      OPTIMIZE,
+
+      NULL,
+
       newcnode_switch(&A, 1,
           SJP_NUMBER, newcnode_bool(&A, JVST_CNODE_AND,
                         newcnode_bool(&A, JVST_CNODE_AND,
@@ -925,6 +932,7 @@ static void test_simplify_ands(void)
                         newcnode(&A,JVST_CNODE_NUM_INTEGER),
                         NULL),
           SJP_NONE),
+
       newcnode_switch(&A, 1,
           SJP_NUMBER, newcnode_bool(&A, JVST_CNODE_AND,
                         newcnode_range(&A, JVST_CNODE_RANGE_MIN, 1.1, 0.0),
@@ -935,7 +943,10 @@ static void test_simplify_ands(void)
 
     // handle more complex nested ANDs
     {
-      OPTIMIZE, NULL,
+      OPTIMIZE,
+      
+      NULL,
+
       newcnode_switch(&A, 1,
           SJP_NUMBER, newcnode_bool(&A, JVST_CNODE_AND,
                         newcnode_bool(&A, JVST_CNODE_AND,
@@ -948,6 +959,7 @@ static void test_simplify_ands(void)
                         newcnode_range(&A, JVST_CNODE_RANGE_MAX, 0.0, 3.2),
                         NULL),
           SJP_NONE),
+
       newcnode_switch(&A, 1,
           SJP_NUMBER, newcnode_bool(&A, JVST_CNODE_AND,
                         newcnode_range(&A, JVST_CNODE_RANGE_MIN, 1.1, 0.0),

--- a/src/test_constraints.c
+++ b/src/test_constraints.c
@@ -745,33 +745,92 @@ void test_xlate_dependencies(void)
   RUNTESTS(tests);
 }
 
-void test_xlate_anyof_1(void)
+void test_xlate_anyof_allof_oneof_1(void)
 {
   struct arena_info A = {0};
-  struct ast_schema *schema = newschema_p(&A, 0,
-      "anyOf", schema_set(&A, 
-        newschema_p(&A, JSON_VALUE_INTEGER, NULL),
-        newschema_p(&A, 0, "minimum", 2.0, NULL),
-        NULL),
-      NULL);
 
   const struct cnode_test tests[] = {
     {
-      TRANSLATE, schema, NULL, newcnode_bool(&A, JVST_CNODE_AND,
-          newcnode_bool(&A, JVST_CNODE_OR,
-            newcnode_switch(&A, 0,
-              SJP_NUMBER, newcnode(&A,JVST_CNODE_NUM_INTEGER),
-              SJP_NONE),
-            newcnode_switch(&A, 1,
-              SJP_NUMBER, newcnode_bool(&A, JVST_CNODE_AND,
-                            newcnode_range(&A, JVST_CNODE_RANGE_MIN, 2.0, 0.0),
-                            newcnode_valid(),
-                            NULL),
-              SJP_NONE),
+      TRANSLATE,
+      newschema_p(&A, 0,
+          "anyOf", schema_set(&A, 
+            newschema_p(&A, JSON_VALUE_INTEGER, NULL),
+            newschema_p(&A, 0, "minimum", 2.0, NULL),
             NULL),
-          newcnode_switch(&A, 1, SJP_NONE),
           NULL),
+
+      NULL,
+
+      newcnode_bool(&A, JVST_CNODE_AND,
+        newcnode_bool(&A, JVST_CNODE_OR,
+          newcnode_switch(&A, 0,
+            SJP_NUMBER, newcnode(&A,JVST_CNODE_NUM_INTEGER),
+            SJP_NONE),
+          newcnode_switch(&A, 1,
+            SJP_NUMBER, newcnode_bool(&A, JVST_CNODE_AND,
+                          newcnode_range(&A, JVST_CNODE_RANGE_MIN, 2.0, 0.0),
+                          newcnode_valid(),
+                          NULL),
+            SJP_NONE),
+          NULL),
+        newcnode_switch(&A, 1, SJP_NONE),
+        NULL),
     },
+
+    {
+      TRANSLATE,
+      newschema_p(&A, 0,
+          "allOf", schema_set(&A, 
+            newschema_p(&A, JSON_VALUE_INTEGER, NULL),
+            newschema_p(&A, 0, "minimum", 2.0, NULL),
+            NULL),
+          NULL),
+
+      NULL,
+
+      newcnode_bool(&A, JVST_CNODE_AND,
+        newcnode_bool(&A, JVST_CNODE_AND,
+          newcnode_switch(&A, 0,
+            SJP_NUMBER, newcnode(&A,JVST_CNODE_NUM_INTEGER),
+            SJP_NONE),
+          newcnode_switch(&A, 1,
+            SJP_NUMBER, newcnode_bool(&A, JVST_CNODE_AND,
+                          newcnode_range(&A, JVST_CNODE_RANGE_MIN, 2.0, 0.0),
+                          newcnode_valid(),
+                          NULL),
+            SJP_NONE),
+          NULL),
+        newcnode_switch(&A, 1, SJP_NONE),
+        NULL),
+    },
+
+    {
+      TRANSLATE,
+      newschema_p(&A, 0,
+          "oneOf", schema_set(&A, 
+            newschema_p(&A, JSON_VALUE_INTEGER, NULL),
+            newschema_p(&A, 0, "minimum", 2.0, NULL),
+            NULL),
+          NULL),
+
+      NULL,
+
+      newcnode_bool(&A, JVST_CNODE_AND,
+        newcnode_bool(&A, JVST_CNODE_XOR,
+          newcnode_switch(&A, 0,
+            SJP_NUMBER, newcnode(&A,JVST_CNODE_NUM_INTEGER),
+            SJP_NONE),
+          newcnode_switch(&A, 1,
+            SJP_NUMBER, newcnode_bool(&A, JVST_CNODE_AND,
+                          newcnode_range(&A, JVST_CNODE_RANGE_MIN, 2.0, 0.0),
+                          newcnode_valid(),
+                          NULL),
+            SJP_NONE),
+          NULL),
+        newcnode_switch(&A, 1, SJP_NONE),
+        NULL),
+    },
+
     { STOP },
   };
 
@@ -1057,7 +1116,7 @@ int main(void)
   test_xlate_required();
   test_xlate_dependencies();
 
-  test_xlate_anyof_1();
+  test_xlate_anyof_allof_oneof_1();
   test_xlate_anyof_2();
 
   test_simplify_ands();

--- a/src/test_constraints.c
+++ b/src/test_constraints.c
@@ -1,0 +1,200 @@
+#include "validate_testing.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "jvst_macros.h"
+
+enum TEST_OP {
+  STOP = 0,
+  TRANSLATE,
+  OPTIMIZE,
+  BOTH,
+
+  // add specific optimization stages...
+  //
+};
+
+struct cnode_test {
+  enum TEST_OP op;
+  struct ast_schema *ast;
+  struct jvst_cnode *cnode;
+  struct jvst_cnode *expected;
+};
+
+static int cnode_trees_equal(struct jvst_cnode *n1, struct jvst_cnode *n2);
+
+static int run_test(const struct cnode_test *t)
+{
+  struct jvst_cnode *result;
+
+  assert(t->expected != NULL);
+
+  switch (t->op) {
+    default:
+    case STOP:
+      fprintf(stderr, "invalid to call run_test(t) with t->op == %d\n", t->op);
+      abort();
+      break;
+
+    case TRANSLATE:
+      assert(t->ast != NULL);
+      result = jvst_cnode_translate_ast(t->ast);
+      break;
+
+    case BOTH:
+      assert(t->ast != NULL);
+      // result = jvst_cnode_from_ast(t->ast);
+      fprintf(stderr, "OPTIMIZE pass not implemented\n");
+      abort();
+      break;
+
+    case OPTIMIZE:
+      assert(t->cnode != NULL);
+      fprintf(stderr, "OPTIMIZE pass not implemented\n");
+      abort();
+  }
+
+  // compare result with expected output
+  return cnode_trees_equal(result, t->expected);
+}
+
+// n1 is actual, n2 is expected
+static int cnode_trees_equal(struct jvst_cnode *n1, struct jvst_cnode *n2)
+{
+  size_t n;
+  int ret, failed;
+  static char buf1[65536];
+  static char buf2[65536];
+  size_t i, linenum, off;
+
+  STATIC_ASSERT(sizeof buf1 == sizeof buf2, buffer_size_not_equal);
+
+  memset(buf1, 0, sizeof buf1);
+  memset(buf2, 0, sizeof buf2);
+
+  // kind of dumb but mostly reliable way to do deep equals...  generate
+  // text dumps and compare
+  // 
+  // XXX - replace with an actual comparison
+  if (jvst_cnode_dump(n1, buf1, sizeof buf1) != 0) {
+    fprintf(stderr, "buffer for node 1 not large enough (currently %zu bytes)\n",
+        sizeof buf1);
+  }
+
+  if (jvst_cnode_dump(n2, buf2, sizeof buf2) != 0) {
+    fprintf(stderr, "buffer for node 2 not large enough (currently %zu bytes)\n",
+        sizeof buf2);
+  }
+
+  if (strncmp(buf1, buf2, sizeof buf1) == 0) {
+    return 1;
+  }
+
+  fprintf(stderr,
+      "cnode trees are not equal:\n"
+      "Expected tree:\n%s\n\n"
+      "Actual tree:\n%s\n",
+      buf2,buf1);
+
+  // slightly tedious job of finding first difference and printing out
+  // both up to that point...
+  for (i=0, linenum=1, off=0; i < sizeof buf1; i++) {
+    size_t j;
+
+    if (buf1[i] == buf2[i]) {
+      if (buf1[i] == '\0') {
+        fprintf(stderr, "INTERNAL ERROR: cannot find difference.\n");
+        abort();
+      }
+
+      if (buf1[i] == '\n') {
+        linenum++;
+        off = i+1;
+      }
+      continue;
+    }
+
+    // difference
+    fprintf(stderr, "difference at line %zu, column %zu:\n", linenum, i-off+1);
+    fprintf(stderr, "EXPECTED: ");
+    for(j=off; j < sizeof buf2 && buf2[j] != '\n'; j++) {
+      fputc(buf2[j], stderr);
+    }
+    fprintf(stderr, "\n");
+
+    fprintf(stderr, "ACTUAL  : ");
+    for(j=off; j < sizeof buf1 && buf1[j] != '\n'; j++) {
+      fputc(buf1[j], stderr);
+    }
+    fprintf(stderr, "\n");
+
+    fprintf(stderr, "DIFF    : ");
+    for(j=off; j < i; j++) {
+      fputc(' ', stderr);
+    }
+    fprintf(stderr, "^\n");
+
+    break;
+  }
+
+  return 0;
+}
+
+#define RUNTESTS(testlist) runtests(__func__, (testlist))
+static void runtests(const char *testname, const struct cnode_test tests[])
+{
+  int i;
+
+  for (i=0; tests[i].op != STOP; i++) {
+    ntest++;
+
+    if (!run_test(&tests[i])) {
+      printf("%s_%d: failed\n", testname, i+1);
+      nfail++;
+    }
+  }
+}
+
+static void test_xlate_empty_schema(void)
+{
+  struct arena_info A = {0};
+
+  const struct cnode_test tests[] = {
+    { TRANSLATE, empty_schema(), NULL, newcnode_switch(&A, 1, SJP_NONE) },
+    { STOP },
+  };
+
+  RUNTESTS(tests);
+}
+
+int main(void)
+{
+  test_xlate_empty_schema();
+
+  /*
+  test_type_integer();
+  test_type_number();
+  test_type_object();
+
+  test_minimum();
+
+  test_properties();
+
+  test_minproperties_1();
+  test_minproperties_2();
+  test_minproperties_3();
+  test_maxproperties_1();
+  test_maxproperties_2();
+  test_minmaxproperties_1();
+
+  test_required();
+
+  test_anyof_1();
+  test_anyof_2();
+  */
+
+  return report_tests();
+}

--- a/src/validate_constraints.c
+++ b/src/validate_constraints.c
@@ -261,6 +261,51 @@ jvst_cnode_free_tree(struct jvst_cnode *root)
 	}
 }
 
+const char *
+jvst_cnode_type_name(enum jvst_cnode_type type)
+{
+	switch (type) {
+	case JVST_CNODE_INVALID:
+		return "INVALID";
+	case JVST_CNODE_VALID:
+		return "VALID";
+	case JVST_CNODE_AND:
+		return "AND";
+	case JVST_CNODE_OR:
+		return "OR";
+	case JVST_CNODE_XOR:
+		return "XOR";
+	case JVST_CNODE_NOT:
+		return "NOT";
+	case JVST_CNODE_SWITCH:
+		return "SWITCH";
+	case JVST_CNODE_COUNT_RANGE:
+		return "COUNT_RANGE";
+	case JVST_CNODE_STR_MATCH:
+		return "STR_MATCH";
+	case JVST_CNODE_NUM_RANGE:
+		return "NUM_RANGE";
+	case JVST_CNODE_NUM_INTEGER:
+		return "NUM_INTEGER";
+	case JVST_CNODE_OBJ_PROP_SET:
+		return "OBJ_PROP_SET";
+	case JVST_CNODE_OBJ_PROP_MATCH:
+		return "OBJ_PROP_MATCH";
+	case JVST_CNODE_OBJ_REQUIRED:
+		return "OBJ_REQUIRED";
+	case JVST_CNODE_ARR_ITEM:
+		return "ARR_ITEM";
+	case JVST_CNODE_ARR_ADDITIONAL:
+		return "ARR_ADDITIONAL";
+	case JVST_CNODE_ARR_UNIQUE:
+		return "ARR_UNIQUE";
+
+	default:
+		fprintf(stderr, "unknown cnode type %d\n", type);
+		abort();
+	}
+}
+
 // returns number of bytes written
 static void
 jvst_cnode_dump_inner(struct jvst_cnode *node, struct sbuf *buf, int indent)

--- a/src/validate_constraints.c
+++ b/src/validate_constraints.c
@@ -142,7 +142,7 @@ new_pool:
   return &p->items[0];
 }
 
-struct jvst_cnode *jvst_cnode_alloc(enum JVST_CNODE_TYPE type)
+struct jvst_cnode *jvst_cnode_alloc(enum jvst_cnode_type type)
 {
   struct jvst_cnode *n;
   n = cnode_new();
@@ -154,7 +154,7 @@ struct jvst_cnode *jvst_cnode_alloc(enum JVST_CNODE_TYPE type)
 static struct jvst_cnode *cnode_new_switch(int allvalid)
 {
   size_t i,n;
-  enum JVST_CNODE_TYPE type;
+  enum jvst_cnode_type type;
   struct jvst_cnode *node, *v, *inv;
 
   node = jvst_cnode_alloc(JVST_CNODE_SWITCH);
@@ -595,7 +595,7 @@ struct jvst_cnode *jvst_cnode_translate_ast(struct ast_schema *ast)
   }
 
   if (ast->kws & (KWS_MINIMUM|KWS_MAXIMUM)) {
-    enum JVST_CNODE_RANGEFLAGS flags = 0;
+    enum jvst_cnode_rangeflags flags = 0;
     double min = 0, max = 0;
     struct jvst_cnode *range, *jxn;
 
@@ -764,7 +764,7 @@ struct jvst_cnode *jvst_cnode_translate_ast(struct ast_schema *ast)
   if (ast->some_of.set != NULL) {
     struct jvst_cnode *top_jxn, *some_jxn, **conds;
     struct ast_schema_set *sset;
-    enum JVST_CNODE_TYPE op = JVST_CNODE_OR;
+    enum jvst_cnode_type op = JVST_CNODE_OR;
 
     if (ast->some_of.min == ast->some_of.max) {
       op = (ast->some_of.min == 1) ? JVST_CNODE_XOR : JVST_CNODE_AND;
@@ -922,7 +922,7 @@ struct jvst_cnode *cnode_list_concat(struct jvst_cnode **headp, struct jvst_cnod
   return *hp0;
 }
 
-static struct jvst_cnode *cnode_find_type(struct jvst_cnode *node, enum JVST_CNODE_TYPE type)
+static struct jvst_cnode *cnode_find_type(struct jvst_cnode *node, enum jvst_cnode_type type)
 {
   for(; node != NULL; node = node->next) {
     if (node->type == type) {

--- a/src/validate_constraints.c
+++ b/src/validate_constraints.c
@@ -36,8 +36,8 @@ struct jvst_cnode_pool {
 
 /* XXX - should these be global vars?  also, not thread safe. */
 static struct jvst_cnode_pool *pool = NULL;
-static size_t pool_item		    = 0;
 static struct jvst_cnode *freelist  = NULL;
+static size_t pool_item	= 0;
 
 struct jvst_strset_pool {
 	struct jvst_strset_pool *next;

--- a/src/validate_constraints.c
+++ b/src/validate_constraints.c
@@ -4,25 +4,108 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h>
 
 #include "xalloc.h"
 
 #include "jvst_macros.h"
 #include "sjp_testing.h"
 
-#define SHOULD_NOT_REACH() abort()
+#define SHOULD_NOT_REACH() do{          \
+  fprintf(stderr, "SHOULD NOT REACH %s, line %d (function %s)\n", \
+      __FILE__, __LINE__, __func__);    \
+  abort();                              \
+} while(0)
 
-enum { JVST_CNODE_CHUNKSIZE = 1024 };
+enum {
+  JVST_CNODE_CHUNKSIZE = 1024,
+  JVST_CNODE_NUMROOTS  = 32,
+};
+
+enum {
+  MARKSIZE = JVST_CNODE_CHUNKSIZE / CHAR_BIT + (JVST_CNODE_CHUNKSIZE % CHAR_BIT) ? 1 : 0,
+};
 
 struct jvst_cnode_pool {
   struct jvst_cnode_pool *next;
   struct jvst_cnode items[JVST_CNODE_CHUNKSIZE];
+  unsigned char marks[MARKSIZE];
 };
 
 /* XXX - should these be global vars?  also, not thread safe. */
 static struct jvst_cnode_pool *pool = NULL;
 static size_t pool_item = 0;
 static struct jvst_cnode *freelist = NULL;
+
+struct jvst_strset_pool {
+  struct jvst_strset_pool *next;
+  struct ast_string_set items[JVST_CNODE_CHUNKSIZE];
+  unsigned char marks[MARKSIZE];
+};
+
+static struct {
+  struct jvst_strset_pool *head;
+  size_t top;
+  struct ast_string_set *freelist;
+} strset_pool;
+
+static struct jvst_cnode *roots[JVST_CNODE_NUMROOTS] = { NULL };
+static int nroots = 0;
+
+static struct ast_string_set *
+cnode_strset_alloc(void)
+{
+  struct jvst_strset_pool *p;
+
+  if (strset_pool.head == NULL) {
+    goto new_pool;
+  }
+
+  // first try bump allocation
+  if (strset_pool.top < ARRAYLEN(strset_pool.head->items)) {
+    return &strset_pool.head->items[pool_item++];
+  }
+
+  // next try the free list
+  if (strset_pool.freelist != NULL) {
+    struct ast_string_set *sset;
+    sset = strset_pool.freelist;
+    strset_pool.freelist = strset_pool.freelist->next;
+    return sset;
+  }
+
+new_pool:
+  // fall back to allocating a new pool
+  p = xmalloc(sizeof *p);
+  p->next = strset_pool.head;
+  strset_pool.head = p;
+  strset_pool.top = 1;
+  return &p->items[0];
+}
+
+static struct ast_string_set *
+cnode_strset(struct json_string str, struct ast_string_set *next)
+{
+  struct ast_string_set *sset;
+  sset = cnode_strset_alloc();
+  sset->str = str;
+  sset->next = next;
+  return sset;
+}
+
+static struct ast_string_set *
+cnode_strset_copy(struct ast_string_set *orig)
+{
+  struct ast_string_set *head, **hpp;
+  head = NULL;
+  hpp = &head;
+  for (; orig != NULL; orig = orig->next) {
+    *hpp = cnode_strset(orig->str, NULL);
+    hpp = &(*hpp)->next;
+  }
+
+  return head;
+}
 
 void json_string_finalize(struct json_string *s)
 {
@@ -71,22 +154,20 @@ struct jvst_cnode *jvst_cnode_alloc(enum JVST_CNODE_TYPE type)
 static struct jvst_cnode *cnode_new_switch(int allvalid)
 {
   size_t i,n;
+  enum JVST_CNODE_TYPE type;
   struct jvst_cnode *node, *v, *inv;
 
   node = jvst_cnode_alloc(JVST_CNODE_SWITCH);
-  v = inv = jvst_cnode_alloc(JVST_CNODE_INVALID);
-  if (allvalid) {
-    v = jvst_cnode_alloc(JVST_CNODE_VALID);
-  }
+  type = allvalid ? JVST_CNODE_VALID : JVST_CNODE_INVALID;
 
   for(i=0, n=ARRAYLEN(node->u.sw); i < n; i++) {
-    node->u.sw[i] = v;
+    node->u.sw[i] = jvst_cnode_alloc(type);
   }
 
   // ARRAY_END and OBJECT_END are always invalid
   if (allvalid) {
-    node->u.sw[SJP_ARRAY_END] = inv;
-    node->u.sw[SJP_OBJECT_END] = inv;
+    node->u.sw[SJP_ARRAY_END] = jvst_cnode_alloc(JVST_CNODE_INVALID);
+    node->u.sw[SJP_OBJECT_END] = jvst_cnode_alloc(JVST_CNODE_INVALID);
   }
 
   return node;
@@ -278,9 +359,9 @@ static void jvst_cnode_dump_inner(struct jvst_cnode *node, struct sbuf *buf, int
       xsnprintf(buf,"x");
 
       if (node->u.num_range.flags & JVST_CNODE_RANGE_EXCL_MAX) {
-        xsnprintf(buf,"< %g", node->u.num_range.min);
+        xsnprintf(buf," < %g", node->u.num_range.max);
       } else if (node->u.num_range.flags & JVST_CNODE_RANGE_MAX) {
-        xsnprintf(buf,"<= %g", node->u.num_range.min);
+        xsnprintf(buf," <= %g", node->u.num_range.max);
       }
 
       xsnprintf(buf,")");
@@ -308,6 +389,25 @@ and_or_xor:
           add_indent(buf,indent+2);
           jvst_cnode_dump_inner(cond, buf, indent+2);
           if (cond->next) {
+            xsnprintf(buf,",\n");
+          } else {
+            xsnprintf(buf,"\n");
+            add_indent(buf,indent);
+            xsnprintf(buf,")");
+          }
+        }
+      }
+      break;
+
+    case JVST_CNODE_OBJ_PROP_SET:
+      {
+        struct jvst_cnode *prop;
+
+        xsnprintf(buf,"PROP_SET(\n");
+        for(prop=node->u.prop_set; prop != NULL; prop = prop->next) {
+          add_indent(buf, indent+2);
+          jvst_cnode_dump_inner(prop, buf, indent+2);
+          if (prop->next) {
             xsnprintf(buf,",\n");
           } else {
             xsnprintf(buf,"\n");
@@ -412,6 +512,17 @@ and_or_xor:
   }
 }
 
+int jvst_cnode_dump(struct jvst_cnode *node, char *buf, size_t nb);
+
+void jvst_cnode_print(struct jvst_cnode *node)
+{
+  // FIXME: gross hack
+  char buf[65536] = { 0 };  // 64K
+
+  jvst_cnode_dump(node, buf, sizeof buf);
+  fprintf(stderr, "%s\n", buf);
+}
+
 int jvst_cnode_dump(struct jvst_cnode *node, char *buf, size_t nb)
 {
   struct sbuf b = {
@@ -510,10 +621,10 @@ struct jvst_cnode *jvst_cnode_translate_ast(struct ast_schema *ast)
   }
 
   if (ast->properties.set != NULL) {
-    struct jvst_cnode **plist, *phead, *prop_jxn, *top_jxn;
+    struct jvst_cnode **plist, *phead, *prop_set, *top_jxn;
     struct ast_property_schema *pset;
 
-    top_jxn = prop_jxn = phead = NULL;
+    top_jxn = prop_set = phead = NULL;
     plist = &phead;
 
     for(pset = ast->properties.set; pset != NULL; pset = pset->next) {
@@ -525,13 +636,13 @@ struct jvst_cnode *jvst_cnode_translate_ast(struct ast_schema *ast)
       plist = &pnode->next;
     }
 
-    prop_jxn = jvst_cnode_alloc(JVST_CNODE_OR);
-    prop_jxn->u.ctrl = phead;
+    prop_set = jvst_cnode_alloc(JVST_CNODE_OBJ_PROP_SET);
+    prop_set->u.prop_set = phead;
     assert(phead != NULL);
 
     top_jxn = jvst_cnode_alloc(JVST_CNODE_AND);
-    top_jxn->u.ctrl = prop_jxn;
-    prop_jxn->next = node->u.sw[SJP_OBJECT_BEG];
+    top_jxn->u.ctrl = prop_set;
+    prop_set->next = node->u.sw[SJP_OBJECT_BEG];
 
     node->u.sw[SJP_OBJECT_BEG] = top_jxn;
   }
@@ -588,4 +699,342 @@ struct jvst_cnode *jvst_cnode_translate_ast(struct ast_schema *ast)
 
   return node;
 }
+
+static struct jvst_cnode *cnode_deep_copy(struct jvst_cnode *node)
+{
+  struct jvst_cnode *tree;
+
+  switch (node->type) {
+    case JVST_CNODE_INVALID:
+    case JVST_CNODE_VALID:
+    case JVST_CNODE_NUM_INTEGER:
+    case JVST_CNODE_ARR_UNIQUE:
+      return jvst_cnode_alloc(node->type);
+
+    case JVST_CNODE_AND:
+    case JVST_CNODE_OR:
+    case JVST_CNODE_XOR:
+    case JVST_CNODE_NOT:
+      {
+        struct jvst_cnode *ctrl, **cp;
+        tree = jvst_cnode_alloc(node->type);
+        cp = &tree->u.ctrl;
+        for (ctrl=node->u.ctrl; ctrl != NULL; ctrl = ctrl->next) {
+          *cp = cnode_deep_copy(ctrl);
+          cp = &(*cp)->next;
+        }
+        return tree;
+      }
+
+    case JVST_CNODE_SWITCH:
+      {
+        size_t i,n;
+        tree = jvst_cnode_alloc(node->type);
+        for (i=0,n=ARRAYLEN(node->u.sw); i < n; i++) {
+          tree->u.sw[i] = NULL;
+          if (node->u.sw[i] != NULL) {
+            tree->u.sw[i] = cnode_deep_copy(node->u.sw[i]);
+          }
+        }
+        return tree;
+      }
+
+    case JVST_CNODE_NUM_RANGE:
+      tree = jvst_cnode_alloc(node->type);
+      tree->u.num_range = node->u.num_range;
+      return tree;
+
+    case JVST_CNODE_COUNT_RANGE:
+      tree = jvst_cnode_alloc(node->type);
+      tree->u.counts = node->u.counts;
+      return tree;
+
+    case JVST_CNODE_STR_MATCH:
+      tree = jvst_cnode_alloc(node->type);
+      tree->u.str_match = node->u.str_match;
+      return tree;
+
+    case JVST_CNODE_OBJ_PROP_SET:
+      {
+        struct jvst_cnode *prop, **pp;
+        tree = jvst_cnode_alloc(node->type);
+        pp = &tree->u.prop_set;
+        for (prop=node->u.prop_set; prop != NULL; prop = prop->next) {
+          *pp = cnode_deep_copy(prop);
+          pp = &(*pp)->next;
+        }
+        return tree;
+      }
+
+    case JVST_CNODE_OBJ_PROP_MATCH:
+      tree = jvst_cnode_alloc(node->type);
+      tree->u.prop_match.match = node->u.prop_match.match;
+      tree->u.prop_match.constraint = cnode_deep_copy(node->u.prop_match.constraint);
+      return tree;
+
+    case JVST_CNODE_OBJ_REQUIRED:
+      tree = jvst_cnode_alloc(node->type);
+      tree->u.required = node->u.required;
+      return tree;
+
+    case JVST_CNODE_ARR_ITEM:
+      {
+        struct jvst_cnode *item, **ip;
+        tree = jvst_cnode_alloc(node->type);
+        ip = &tree->u.arr_item;
+        for (item=node->u.arr_item; item != NULL; item = item->next) {
+          *ip = cnode_deep_copy(item);
+          ip = &(*ip)->next;
+        }
+        return tree;
+      }
+
+    case JVST_CNODE_ARR_ADDITIONAL:
+      tree = jvst_cnode_alloc(node->type);
+      tree->u.arr_item = cnode_deep_copy(node->u.arr_item);
+      return tree;
+
+    default:
+      SHOULD_NOT_REACH();
+  }
+
+  // now free the node
+  jvst_cnode_free(node);
+}
+
+struct jvst_cnode *cnode_list_end(struct jvst_cnode *node)
+{
+  assert(node != NULL);
+  while (node->next != NULL) {
+    node = node->next;
+  }
+  return node;
+}
+
+struct jvst_cnode *cnode_list_prepend(struct jvst_cnode **headp, struct jvst_cnode *node)
+{
+  assert(headp != NULL);
+  node->next = *headp;
+  *headp = node;
+  return node;
+}
+
+struct jvst_cnode *cnode_list_concat(struct jvst_cnode **headp, struct jvst_cnode *tail)
+{
+  struct jvst_cnode **hp0;
+
+  hp0 = headp;
+
+  assert(headp != NULL);
+  while (*headp != NULL) {
+    headp = &(*headp)->next;
+  }
+  *headp = tail;
+  return *hp0;
+}
+
+static struct jvst_cnode *cnode_find_type(struct jvst_cnode *node, enum JVST_CNODE_TYPE type)
+{
+  for(; node != NULL; node = node->next) {
+    if (node->type == type) {
+      return node;
+    }
+  }
+
+  return NULL;
+}
+
+static struct jvst_cnode *cnode_optimize_andor_switches(struct jvst_cnode *top)
+{
+  // check if all nodes are SWITCH nodes.  If they are, combine
+  // the switch clauses and simplify
+
+  struct jvst_cnode *node, **pp, *sw;
+  size_t i,n;
+
+  for(node=top->u.ctrl; node != NULL; node = node->next) {
+    if (node->type != JVST_CNODE_SWITCH) {
+      return top;
+    }
+  }
+
+  // all nodes are switch nodes...
+  sw = jvst_cnode_alloc(JVST_CNODE_SWITCH);
+  for (i=0, n=ARRAYLEN(sw->u.sw); i < n; i++) {
+    struct jvst_cnode *jxn, **cpp;
+
+    jxn = jvst_cnode_alloc(top->type);
+    cpp = &jxn->u.ctrl;
+
+    for(node=top->u.ctrl; node != NULL; node = node->next) {
+      assert(node->type == JVST_CNODE_SWITCH);
+
+      *cpp = node->u.sw[i];
+      assert( (*cpp)->next == NULL );
+      cpp = &(*cpp)->next;
+    }
+
+    sw->u.sw[i] = jvst_cnode_optimize(jxn);
+  }
+
+  return sw;
+}
+
+static struct jvst_cnode *cnode_optimize_andor(struct jvst_cnode *top)
+{
+  struct jvst_cnode *node, *next, **pp;
+  pp = &top->u.ctrl;
+
+  // first optimize child nodes...
+  for(node=top->u.ctrl; node != NULL; node = next) {
+    next = node->next;
+    *pp = jvst_cnode_optimize(node);
+    pp = &(*pp)->next;
+  }
+
+  // pass 1: remove VALID/INVALID nodes
+  switch (top->type) {
+    case JVST_CNODE_AND:
+      for(pp = &top->u.ctrl; *pp != NULL;) {
+        switch ((*pp)->type) {
+          case JVST_CNODE_INVALID:
+            // whole AND becomes invalid
+            (*pp)->next = NULL;
+            return *pp;
+
+          case JVST_CNODE_VALID:
+            // can eliminate VALID from AND
+            *pp = (*pp)->next;
+            continue;
+
+          default:
+            break;
+        }
+
+        pp = &(*pp)->next;
+      }
+
+      // all nodes were valid
+      if (top->u.ctrl == NULL) {
+        return jvst_cnode_alloc(JVST_CNODE_VALID);
+      }
+      break;
+
+    case JVST_CNODE_OR:
+      for(pp = &top->u.ctrl; *pp != NULL;) {
+        switch ((*pp)->type) {
+          case JVST_CNODE_VALID:
+            // whole OR becomes valid
+            (*pp)->next = NULL;
+            return *pp;
+
+          case JVST_CNODE_INVALID:
+            // can eliminate INVALID from OR
+            *pp = (*pp)->next;
+            continue;
+
+          default:
+            break;
+        }
+
+        pp = &(*pp)->next;
+      }
+
+      // all nodes were invalid
+      if (top->u.ctrl == NULL) {
+        return jvst_cnode_alloc(JVST_CNODE_INVALID);
+      }
+      break;
+
+    default:
+      SHOULD_NOT_REACH();
+  }
+
+  assert(top->u.ctrl != NULL);
+  if (top->u.ctrl->next == NULL) {
+    // only one child
+    return top->u.ctrl;
+  }
+
+  // pass 2: combine subnodes of the same type (ie: AND will combine
+  // with AND and OR will combine with OR)
+  for(pp = &top->u.ctrl; *pp != NULL; pp = &(*pp)->next) {
+    struct jvst_cnode *head, *tail;
+
+    if ((*pp)->type != top->type) {
+      continue;
+    }
+
+    // save next link
+    next = (*pp)->next;
+    *pp = (*pp)->u.ctrl;
+
+    // fast path...
+    if (next == NULL) {
+      continue;
+    }
+
+    while (*pp != NULL) {
+      pp = &(*pp)->next;
+    }
+
+    *pp = next;
+  }
+
+  return cnode_optimize_andor_switches(top);
+}
+
+struct jvst_cnode *jvst_cnode_optimize(struct jvst_cnode *tree)
+{
+  struct jvst_cnode *node;
+
+  // make a copy
+  tree = cnode_deep_copy(tree);
+
+  switch (tree->type) {
+    case JVST_CNODE_INVALID:
+    case JVST_CNODE_VALID:
+    case JVST_CNODE_NUM_INTEGER:
+    case JVST_CNODE_ARR_UNIQUE:
+      return tree;
+
+    case JVST_CNODE_AND:
+    case JVST_CNODE_OR:
+      return cnode_optimize_andor(tree);
+
+    case JVST_CNODE_XOR:
+      // TODO: basic optimization for XOR
+      return tree;
+
+    case JVST_CNODE_NOT:
+      // TODO: basic optimizations for NOT
+      return tree;
+
+    case JVST_CNODE_SWITCH:
+      {
+        size_t i,n;
+        for(i=0, n=ARRAYLEN(tree->u.sw); i < n; i++) {
+          tree->u.sw[i] = jvst_cnode_optimize(tree->u.sw[i]);
+        }
+      }
+      return tree;
+
+    case JVST_CNODE_OBJ_PROP_SET:
+    case JVST_CNODE_NUM_RANGE:
+    case JVST_CNODE_COUNT_RANGE:
+    case JVST_CNODE_STR_MATCH:
+    case JVST_CNODE_OBJ_PROP_MATCH:
+    case JVST_CNODE_OBJ_REQUIRED:
+    case JVST_CNODE_ARR_ITEM:
+    case JVST_CNODE_ARR_ADDITIONAL:
+      // TODO: basic optimization for these nodes
+      return tree;
+
+    default:
+      SHOULD_NOT_REACH();
+  }
+}
+
+
+
 

--- a/src/validate_constraints.c
+++ b/src/validate_constraints.c
@@ -11,1119 +11,1142 @@
 #include "jvst_macros.h"
 #include "sjp_testing.h"
 
-#define SHOULD_NOT_REACH() do{          \
-  fprintf(stderr, "SHOULD NOT REACH %s, line %d (function %s)\n", \
-      __FILE__, __LINE__, __func__);    \
-  abort();                              \
-} while(0)
+#define SHOULD_NOT_REACH()							\
+	do {									\
+		fprintf(stderr, "SHOULD NOT REACH %s, line %d (function %s)\n",	\
+			__FILE__, __LINE__, __func__);				\
+		abort();							\
+	} while (0)
 
 enum {
-  JVST_CNODE_CHUNKSIZE = 1024,
-  JVST_CNODE_NUMROOTS  = 32,
+	JVST_CNODE_CHUNKSIZE = 1024,
+	JVST_CNODE_NUMROOTS  = 32,
 };
 
 enum {
-  MARKSIZE = JVST_CNODE_CHUNKSIZE / CHAR_BIT + (JVST_CNODE_CHUNKSIZE % CHAR_BIT) ? 1 : 0,
+	MARKSIZE = JVST_CNODE_CHUNKSIZE / CHAR_BIT +
+		(JVST_CNODE_CHUNKSIZE % CHAR_BIT) ? 1 : 0,
 };
 
 struct jvst_cnode_pool {
-  struct jvst_cnode_pool *next;
-  struct jvst_cnode items[JVST_CNODE_CHUNKSIZE];
-  unsigned char marks[MARKSIZE];
+	struct jvst_cnode_pool *next;
+	struct jvst_cnode items[JVST_CNODE_CHUNKSIZE];
+	unsigned char marks[MARKSIZE];
 };
 
 /* XXX - should these be global vars?  also, not thread safe. */
 static struct jvst_cnode_pool *pool = NULL;
-static size_t pool_item = 0;
-static struct jvst_cnode *freelist = NULL;
+static size_t pool_item		    = 0;
+static struct jvst_cnode *freelist  = NULL;
 
 struct jvst_strset_pool {
-  struct jvst_strset_pool *next;
-  struct ast_string_set items[JVST_CNODE_CHUNKSIZE];
-  unsigned char marks[MARKSIZE];
+	struct jvst_strset_pool *next;
+	struct ast_string_set items[JVST_CNODE_CHUNKSIZE];
+	unsigned char marks[MARKSIZE];
 };
 
 static struct {
-  struct jvst_strset_pool *head;
-  size_t top;
-  struct ast_string_set *freelist;
+	struct jvst_strset_pool *head;
+	size_t top;
+	struct ast_string_set *freelist;
 } strset_pool;
 
-static struct jvst_cnode *roots[JVST_CNODE_NUMROOTS] = { NULL };
-static int nroots = 0;
+static struct jvst_cnode *roots[JVST_CNODE_NUMROOTS] = {NULL};
+static int nroots				     = 0;
 
 static struct ast_string_set *
 cnode_strset_alloc(void)
 {
-  struct jvst_strset_pool *p;
+	struct jvst_strset_pool *p;
 
-  if (strset_pool.head == NULL) {
-    goto new_pool;
-  }
+	if (strset_pool.head == NULL) {
+		goto new_pool;
+	}
 
-  // first try bump allocation
-  if (strset_pool.top < ARRAYLEN(strset_pool.head->items)) {
-    return &strset_pool.head->items[pool_item++];
-  }
+	// first try bump allocation
+	if (strset_pool.top < ARRAYLEN(strset_pool.head->items)) {
+		return &strset_pool.head->items[pool_item++];
+	}
 
-  // next try the free list
-  if (strset_pool.freelist != NULL) {
-    struct ast_string_set *sset;
-    sset = strset_pool.freelist;
-    strset_pool.freelist = strset_pool.freelist->next;
-    return sset;
-  }
+	// next try the free list
+	if (strset_pool.freelist != NULL) {
+		struct ast_string_set *sset;
+		sset		     = strset_pool.freelist;
+		strset_pool.freelist = strset_pool.freelist->next;
+		return sset;
+	}
 
 new_pool:
-  // fall back to allocating a new pool
-  p = xmalloc(sizeof *p);
-  p->next = strset_pool.head;
-  strset_pool.head = p;
-  strset_pool.top = 1;
-  return &p->items[0];
+	// fall back to allocating a new pool
+	p		 = xmalloc(sizeof *p);
+	p->next		 = strset_pool.head;
+	strset_pool.head = p;
+	strset_pool.top  = 1;
+	return &p->items[0];
 }
 
 static struct ast_string_set *
 cnode_strset(struct json_string str, struct ast_string_set *next)
 {
-  struct ast_string_set *sset;
-  sset = cnode_strset_alloc();
-  sset->str = str;
-  sset->next = next;
-  return sset;
+	struct ast_string_set *sset;
+	sset       = cnode_strset_alloc();
+	sset->str  = str;
+	sset->next = next;
+	return sset;
 }
 
 static struct ast_string_set *
 cnode_strset_copy(struct ast_string_set *orig)
 {
-  struct ast_string_set *head, **hpp;
-  head = NULL;
-  hpp = &head;
-  for (; orig != NULL; orig = orig->next) {
-    *hpp = cnode_strset(orig->str, NULL);
-    hpp = &(*hpp)->next;
-  }
+	struct ast_string_set *head, **hpp;
+	head = NULL;
+	hpp  = &head;
+	for (; orig != NULL; orig = orig->next) {
+		*hpp = cnode_strset(orig->str, NULL);
+		hpp  = &(*hpp)->next;
+	}
 
-  return head;
+	return head;
 }
 
-void json_string_finalize(struct json_string *s)
+void
+json_string_finalize(struct json_string *s)
 {
-  // XXX - implement
-  (void)s;
+	// XXX - implement
+	(void)s;
 }
 
-static struct jvst_cnode *cnode_new(void)
+static struct jvst_cnode *
+cnode_new(void)
 {
-  struct jvst_cnode_pool *p;
+	struct jvst_cnode_pool *p;
 
-  if (pool == NULL) {
-    goto new_pool;
-  }
+	if (pool == NULL) {
+		goto new_pool;
+	}
 
-  // first try bump allocation
-  if (pool_item < ARRAYLEN(pool->items)) {
-    return &pool->items[pool_item++];
-  }
+	// first try bump allocation
+	if (pool_item < ARRAYLEN(pool->items)) {
+		return &pool->items[pool_item++];
+	}
 
-  // next try the free list
-  if (freelist != NULL) {
-    struct jvst_cnode *n = freelist;
-    freelist = freelist->next;
-    return n;
-  }
+	// next try the free list
+	if (freelist != NULL) {
+		struct jvst_cnode *n = freelist;
+		freelist	     = freelist->next;
+		return n;
+	}
 
 new_pool:
-  // fall back to allocating a new pool
-  p = xmalloc(sizeof *p);
-  p->next = pool;
-  pool = p;
-  pool_item = 1;
-  return &p->items[0];
+	// fall back to allocating a new pool
+	p	 = xmalloc(sizeof *p);
+	p->next   = pool;
+	pool      = p;
+	pool_item = 1;
+	return &p->items[0];
 }
 
-struct jvst_cnode *jvst_cnode_alloc(enum jvst_cnode_type type)
+struct jvst_cnode *
+jvst_cnode_alloc(enum jvst_cnode_type type)
 {
-  struct jvst_cnode *n;
-  n = cnode_new();
-  n->type = type;
-  n->next = NULL;
-  return n;
+	struct jvst_cnode *n;
+	n       = cnode_new();
+	n->type = type;
+	n->next = NULL;
+	return n;
 }
 
-static struct jvst_cnode *cnode_new_switch(int allvalid)
+static struct jvst_cnode *
+cnode_new_switch(int allvalid)
 {
-  size_t i,n;
-  enum jvst_cnode_type type;
-  struct jvst_cnode *node, *v, *inv;
+	size_t i, n;
+	enum jvst_cnode_type type;
+	struct jvst_cnode *node, *v, *inv;
 
-  node = jvst_cnode_alloc(JVST_CNODE_SWITCH);
-  type = allvalid ? JVST_CNODE_VALID : JVST_CNODE_INVALID;
+	node = jvst_cnode_alloc(JVST_CNODE_SWITCH);
+	type = allvalid ? JVST_CNODE_VALID : JVST_CNODE_INVALID;
 
-  for(i=0, n=ARRAYLEN(node->u.sw); i < n; i++) {
-    node->u.sw[i] = jvst_cnode_alloc(type);
-  }
+	for (i = 0, n = ARRAYLEN(node->u.sw); i < n; i++) {
+		node->u.sw[i] = jvst_cnode_alloc(type);
+	}
 
-  // ARRAY_END and OBJECT_END are always invalid
-  if (allvalid) {
-    node->u.sw[SJP_ARRAY_END] = jvst_cnode_alloc(JVST_CNODE_INVALID);
-    node->u.sw[SJP_OBJECT_END] = jvst_cnode_alloc(JVST_CNODE_INVALID);
-  }
+	// ARRAY_END and OBJECT_END are always invalid
+	if (allvalid) {
+		node->u.sw[SJP_ARRAY_END]  = jvst_cnode_alloc(JVST_CNODE_INVALID);
+		node->u.sw[SJP_OBJECT_END] = jvst_cnode_alloc(JVST_CNODE_INVALID);
+	}
 
-  return node;
+	return node;
 }
 
-void jvst_cnode_free(struct jvst_cnode *n)
+void
+jvst_cnode_free(struct jvst_cnode *n)
 {
-  // simple logic: add back to freelist
-  memset(n, 0, sizeof *n);
-  n->next = freelist;
-  freelist = n;
+	// simple logic: add back to freelist
+	memset(n, 0, sizeof *n);
+	n->next  = freelist;
+	freelist = n;
 }
 
-void jvst_cnode_free_tree(struct jvst_cnode *root)
+void
+jvst_cnode_free_tree(struct jvst_cnode *root)
 {
-  struct jvst_cnode *node, *next;
-  size_t i,n;
+	struct jvst_cnode *node, *next;
+	size_t i, n;
 
-  for(node = root; node != NULL; node = next) {
-    next = node->next;
+	for (node = root; node != NULL; node = next) {
+		next = node->next;
 
-    switch (node->type) {
-      case JVST_CNODE_INVALID:
-      case JVST_CNODE_VALID:
-        break;
+		switch (node->type) {
+		case JVST_CNODE_INVALID:
+		case JVST_CNODE_VALID:
+			break;
 
-      case JVST_CNODE_AND:
-      case JVST_CNODE_OR:
-      case JVST_CNODE_XOR:
-      case JVST_CNODE_NOT:
-        jvst_cnode_free_tree(node->u.ctrl);
-        break;
+		case JVST_CNODE_AND:
+		case JVST_CNODE_OR:
+		case JVST_CNODE_XOR:
+		case JVST_CNODE_NOT:
+			jvst_cnode_free_tree(node->u.ctrl);
+			break;
 
-      case JVST_CNODE_SWITCH:
-        for (i=0,n=ARRAYLEN(node->u.sw); i < n; i++) {
-          if (node->u.sw[i] != NULL) {
-            jvst_cnode_free_tree(node->u.sw[i]);
-          }
-        }
-        break;
+		case JVST_CNODE_SWITCH:
+			for (i = 0, n = ARRAYLEN(node->u.sw); i < n; i++) {
+				if (node->u.sw[i] != NULL) {
+					jvst_cnode_free_tree(node->u.sw[i]);
+				}
+			}
+			break;
 
-      /* constrains with no child nodes */
-      case JVST_CNODE_NUM_INTEGER:
-      case JVST_CNODE_NUM_RANGE:
-      case JVST_CNODE_COUNT_RANGE:
-      case JVST_CNODE_ARR_UNIQUE:
-        break;
+		/* constrains with no child nodes */
+		case JVST_CNODE_NUM_INTEGER:
+		case JVST_CNODE_NUM_RANGE:
+		case JVST_CNODE_COUNT_RANGE:
+		case JVST_CNODE_ARR_UNIQUE:
+			break;
 
-      case JVST_CNODE_STR_MATCH:
-        // XXX - need to handle FSM cleanup
-        // pool FSMs?  ref count them?
-        //
-        // be lazy about it, keep references to temporaries,
-        // recreate the fsm from scratch when we're done and delete
-        // the temporaries?
-        break;
+		case JVST_CNODE_STR_MATCH:
+			// XXX - need to handle FSM cleanup
+			// pool FSMs?  ref count them?
+			//
+			// be lazy about it, keep references to temporaries,
+			// recreate the fsm from scratch when we're done and delete
+			// the temporaries?
+			break;
 
-      case JVST_CNODE_OBJ_PROP_MATCH:
-        // XXX - ensure that fsm is torn down
-        // do we pool FSMs?  check if they're ref counted.
-        assert(node->u.prop_match.constraint != NULL);
-        jvst_cnode_free_tree(node->u.prop_match.constraint);
-        break;
+		case JVST_CNODE_OBJ_PROP_MATCH:
+			// XXX - ensure that fsm is torn down
+			// do we pool FSMs?  check if they're ref counted.
+			assert(node->u.prop_match.constraint != NULL);
+			jvst_cnode_free_tree(node->u.prop_match.constraint);
+			break;
 
-      case JVST_CNODE_OBJ_REQUIRED:
-        // XXX - finalize the string set?
-        break;
+		case JVST_CNODE_OBJ_REQUIRED:
+			// XXX - finalize the string set?
+			break;
 
-      case JVST_CNODE_ARR_ITEM:
-      case JVST_CNODE_ARR_ADDITIONAL:
-        if (node->u.arr_item != NULL) {
-          jvst_cnode_free_tree(node->u.arr_item);
-        }
-        break;
+		case JVST_CNODE_ARR_ITEM:
+		case JVST_CNODE_ARR_ADDITIONAL:
+			if (node->u.arr_item != NULL) {
+				jvst_cnode_free_tree(node->u.arr_item);
+			}
+			break;
 
-      default:
-        SHOULD_NOT_REACH();
-    }
+		default:
+			SHOULD_NOT_REACH();
+		}
 
-    // now free the node
-    jvst_cnode_free(node);
-  }
+		// now free the node
+		jvst_cnode_free(node);
+	}
 }
 
 struct sbuf {
-  char *buf;
-  size_t cap;
-  size_t len;
-  size_t np;
+	char *buf;
+	size_t cap;
+	size_t len;
+	size_t np;
 };
 
-static int add_indent(struct sbuf *buf, int indent)
+static int
+add_indent(struct sbuf *buf, int indent)
 {
-  int i;
-  
-  for (i=0; i < indent; i++) {
-    if (buf->len >= buf->cap) {
-      break;
-    }
-    buf->buf[buf->len++] = ' ';
-  }
+	int i;
 
-  buf->np += indent;
+	for (i = 0; i < indent; i++) {
+		if (buf->len >= buf->cap) {
+			break;
+		}
+		buf->buf[buf->len++] = ' ';
+	}
 
-  return indent;
+	buf->np += indent;
+
+	return indent;
 }
 
-static void xsnprintf(struct sbuf *b, const char *fmt, ...)
+static void
+xsnprintf(struct sbuf *b, const char *fmt, ...)
 {
-  int ret;
-  va_list args;
-  char *p;
-  size_t nb;
+	int ret;
+	va_list args;
+	char *p;
+	size_t nb;
 
-  assert(b->len <= b->cap);
+	assert(b->len <= b->cap);
 
-  p = b->buf+b->len;
-  nb = b->cap - b->len;
+	p  = b->buf + b->len;
+	nb = b->cap - b->len;
 
-  va_start(args, fmt);
-  ret = vsnprintf(p,nb,fmt,args);
-  va_end(args);
-  if (ret < 0) {
-    // FIXME: handle this more gracefully!
-    perror("ERROR dumping cnode to a buffer");
-    abort();
-  }
+	va_start(args, fmt);
+	ret = vsnprintf(p, nb, fmt, args);
+	va_end(args);
+	if (ret < 0) {
+		// FIXME: handle this more gracefully!
+		perror("ERROR dumping cnode to a buffer");
+		abort();
+	}
 
-  if ((size_t)ret <= nb) {
-    b->len += ret;
-  } else {
-    b->len = b->cap;
-  }
+	if ((size_t)ret <= nb) {
+		b->len += ret;
+	} else {
+		b->len = b->cap;
+	}
 
-  b->np += ret;
+	b->np += ret;
 }
-
-
 
 // returns number of bytes written
-static void jvst_cnode_dump_inner(struct jvst_cnode *node, struct sbuf *buf, int indent)
+static void
+jvst_cnode_dump_inner(struct jvst_cnode *node, struct sbuf *buf, int indent)
 {
-  const char *op = NULL;
+	const char *op = NULL;
 
-  if (node == NULL) {
-    xsnprintf(buf, "<null>");
-    return;
-  }
+	if (node == NULL) {
+		xsnprintf(buf, "<null>");
+		return;
+	}
 
-  switch (node->type) {
-    case JVST_CNODE_INVALID:
-    case JVST_CNODE_VALID:
-      xsnprintf(buf, (node->type == JVST_CNODE_VALID) ? "VALID" : "INVALID");
-      return;
+	switch (node->type) {
+	case JVST_CNODE_INVALID:
+	case JVST_CNODE_VALID:
+		xsnprintf(buf, (node->type == JVST_CNODE_VALID) ? "VALID" : "INVALID");
+		return;
 
-    case JVST_CNODE_SWITCH:
-      {
-        size_t i,n;
+	case JVST_CNODE_SWITCH:
+		{
+			size_t i, n;
 
-        xsnprintf(buf, "SWITCH(\n");
-        n = ARRAYLEN(node->u.sw);
-        for (i=0; i < n; i++) {
-          add_indent(buf,indent+2);
-          xsnprintf(buf,"%-10s : ", evt2name(i));
-          jvst_cnode_dump_inner(node->u.sw[i], buf, indent+2);
-          if (i < n-1) {
-            xsnprintf(buf,",\n");
-          } else {
-            xsnprintf(buf,"\n");
-            add_indent(buf,indent);
-            xsnprintf(buf,")");
-          }
-        }
-      }
-      break;
+			xsnprintf(buf, "SWITCH(\n");
+			n = ARRAYLEN(node->u.sw);
+			for (i = 0; i < n; i++) {
+				add_indent(buf, indent + 2);
+				xsnprintf(buf, "%-10s : ", evt2name(i));
+				jvst_cnode_dump_inner(node->u.sw[i], buf, indent + 2);
+				if (i < n - 1) {
+					xsnprintf(buf, ",\n");
+				} else {
+					xsnprintf(buf, "\n");
+					add_indent(buf, indent);
+					xsnprintf(buf, ")");
+				}
+			}
+		}
+		break;
 
-    case JVST_CNODE_NUM_INTEGER:
-      xsnprintf(buf,"IS_INTEGER");
-      break;
+	case JVST_CNODE_NUM_INTEGER:
+		xsnprintf(buf, "IS_INTEGER");
+		break;
 
-    case JVST_CNODE_NUM_RANGE:
-      xsnprintf(buf,"NUM_RANGE(");
-      if (node->u.num_range.flags & JVST_CNODE_RANGE_EXCL_MIN) {
-        xsnprintf(buf,"%g < ", node->u.num_range.min);
-      } else if (node->u.num_range.flags & JVST_CNODE_RANGE_MIN) {
-        xsnprintf(buf,"%g <= ", node->u.num_range.min);
-      }
+	case JVST_CNODE_NUM_RANGE:
+		xsnprintf(buf, "NUM_RANGE(");
+		if (node->u.num_range.flags & JVST_CNODE_RANGE_EXCL_MIN) {
+			xsnprintf(buf, "%g < ", node->u.num_range.min);
+		} else if (node->u.num_range.flags & JVST_CNODE_RANGE_MIN) {
+			xsnprintf(buf, "%g <= ", node->u.num_range.min);
+		}
 
-      xsnprintf(buf,"x");
+		xsnprintf(buf, "x");
 
-      if (node->u.num_range.flags & JVST_CNODE_RANGE_EXCL_MAX) {
-        xsnprintf(buf," < %g", node->u.num_range.max);
-      } else if (node->u.num_range.flags & JVST_CNODE_RANGE_MAX) {
-        xsnprintf(buf," <= %g", node->u.num_range.max);
-      }
+		if (node->u.num_range.flags & JVST_CNODE_RANGE_EXCL_MAX) {
+			xsnprintf(buf, " < %g", node->u.num_range.max);
+		} else if (node->u.num_range.flags & JVST_CNODE_RANGE_MAX) {
+			xsnprintf(buf, " <= %g", node->u.num_range.max);
+		}
 
-      xsnprintf(buf,")");
-      break;
+		xsnprintf(buf, ")");
+		break;
 
-    case JVST_CNODE_AND:
-      op = "AND";
-      goto and_or_xor;
+	case JVST_CNODE_AND:
+		op = "AND";
+		goto and_or_xor;
 
-    case JVST_CNODE_OR:
-      op = "OR";
-      goto and_or_xor;
-      /* fallthrough */
+	case JVST_CNODE_OR:
+		op = "OR";
+		goto and_or_xor;
+	/* fallthrough */
 
-    case JVST_CNODE_XOR:
-      op = "XOR";
-      goto and_or_xor;
+	case JVST_CNODE_XOR:
+		op = "XOR";
+		goto and_or_xor;
 
 and_or_xor:
-      {
-        struct jvst_cnode *cond;
+		{
+			struct jvst_cnode *cond;
 
-        xsnprintf(buf, "%s(\n", op);
-        for(cond = node->u.ctrl; cond != NULL; cond = cond->next) {
-          add_indent(buf,indent+2);
-          jvst_cnode_dump_inner(cond, buf, indent+2);
-          if (cond->next) {
-            xsnprintf(buf,",\n");
-          } else {
-            xsnprintf(buf,"\n");
-            add_indent(buf,indent);
-            xsnprintf(buf,")");
-          }
-        }
-      }
-      break;
+			xsnprintf(buf, "%s(\n", op);
+			for (cond = node->u.ctrl; cond != NULL; cond = cond->next) {
+				add_indent(buf, indent + 2);
+				jvst_cnode_dump_inner(cond, buf, indent + 2);
+				if (cond->next) {
+					xsnprintf(buf, ",\n");
+				} else {
+					xsnprintf(buf, "\n");
+					add_indent(buf, indent);
+					xsnprintf(buf, ")");
+				}
+			}
+		}
+		break;
 
-    case JVST_CNODE_OBJ_PROP_SET:
-      {
-        struct jvst_cnode *prop;
+	case JVST_CNODE_OBJ_PROP_SET:
+		{
+			struct jvst_cnode *prop;
 
-        xsnprintf(buf,"PROP_SET(\n");
-        for(prop=node->u.prop_set; prop != NULL; prop = prop->next) {
-          add_indent(buf, indent+2);
-          jvst_cnode_dump_inner(prop, buf, indent+2);
-          if (prop->next) {
-            xsnprintf(buf,",\n");
-          } else {
-            xsnprintf(buf,"\n");
-            add_indent(buf,indent);
-            xsnprintf(buf,")");
-          }
-        }
-      }
-      break;
+			xsnprintf(buf, "PROP_SET(\n");
+			for (prop = node->u.prop_set; prop != NULL; prop = prop->next) {
+				add_indent(buf, indent + 2);
+				jvst_cnode_dump_inner(prop, buf, indent + 2);
+				if (prop->next) {
+					xsnprintf(buf, ",\n");
+				} else {
+					xsnprintf(buf, "\n");
+					add_indent(buf, indent);
+					xsnprintf(buf, ")");
+				}
+			}
+		}
+		break;
 
-    case JVST_CNODE_OBJ_PROP_MATCH:
-      {
-        char match[256] = { 0 };
-        if (node->u.prop_match.match.str.len >= sizeof match) {
-          memcpy(match, node->u.prop_match.match.str.s, sizeof match - 4);
-          match[sizeof match - 4] = '.';
-          match[sizeof match - 3] = '.';
-          match[sizeof match - 2] = '.';
-        } else {
-          memcpy(match, node->u.prop_match.match.str.s, node->u.prop_match.match.str.len);
-        }
+	case JVST_CNODE_OBJ_PROP_MATCH:
+		{
+			char match[256] = {0};
+			if (node->u.prop_match.match.str.len >= sizeof match) {
+				memcpy(match, node->u.prop_match.match.str.s, sizeof match - 4);
+				match[sizeof match - 4] = '.';
+				match[sizeof match - 3] = '.';
+				match[sizeof match - 2] = '.';
+			} else {
+				memcpy(match, node->u.prop_match.match.str.s,
+						node->u.prop_match.match.str.len);
+			}
 
-        xsnprintf(buf,"PROP_MATCH(\n");
-        add_indent(buf, indent+2);
-        {
-          char *prefix = "";
-          char delim = '/';
-          switch (node->u.prop_match.match.dialect) {
-            case RE_LIKE:
-              prefix="L";
-              break;
-            case RE_LITERAL:
-              delim = '"';
-              break;
+			xsnprintf(buf, "PROP_MATCH(\n");
+			add_indent(buf, indent + 2);
+			{
+				char *prefix = "";
+				char delim   = '/';
+				switch (node->u.prop_match.match.dialect) {
+					case RE_LIKE:
+						prefix = "L";
+						break;
+					case RE_LITERAL:
+						delim = '"';
+						break;
 
-            case RE_GLOB:
-              prefix="G";
-              break;
-            case RE_NATIVE:
-              break;
-            default:
-              prefix="???";
-              break;
-          }
-          xsnprintf(buf,"%s%c%s%c,\n", prefix,delim,match,delim);
-          add_indent(buf, indent+2);
-          jvst_cnode_dump_inner(node->u.prop_match.constraint, buf, indent+2);
-          xsnprintf(buf,"\n");
-          add_indent(buf,indent);
-          xsnprintf(buf,")");
-        }
-      }
-      break;
+					case RE_GLOB:
+						prefix = "G";
+						break;
+					case RE_NATIVE:
+						break;
+					default:
+						prefix = "???";
+						break;
+				}
+				xsnprintf(buf, "%s%c%s%c,\n", prefix, delim, match, delim);
+				add_indent(buf, indent + 2);
+				jvst_cnode_dump_inner(node->u.prop_match.constraint, buf, indent + 2);
+				xsnprintf(buf, "\n");
+				add_indent(buf, indent);
+				xsnprintf(buf, ")");
+			}
+		}
+		break;
 
-    case JVST_CNODE_COUNT_RANGE:
-      xsnprintf(buf,"COUNT_RANGE(");
-      if (node->u.counts.min > 0) {
-        xsnprintf(buf,"%zu <= ", node->u.counts.min);
-      }
+	case JVST_CNODE_COUNT_RANGE:
+		xsnprintf(buf, "COUNT_RANGE(");
+		if (node->u.counts.min > 0) {
+			xsnprintf(buf, "%zu <= ", node->u.counts.min);
+		}
 
-      xsnprintf(buf,"x");
+		xsnprintf(buf, "x");
 
-      if (node->u.counts.max > 0) {
-        xsnprintf(buf,"<= %zu", node->u.counts.min);
-      }
+		if (node->u.counts.max > 0) {
+			xsnprintf(buf, "<= %zu", node->u.counts.min);
+		}
 
-      xsnprintf(buf,")");
-      break;
+		xsnprintf(buf, ")");
+		break;
 
-    case JVST_CNODE_OBJ_REQUIRED:
-      {
-        struct ast_string_set *ss;
+	case JVST_CNODE_OBJ_REQUIRED:
+		{
+			struct ast_string_set *ss;
 
-        xsnprintf(buf,"REQUIRED(\n");
-        for (ss = node->u.required; ss != NULL; ss = ss->next) {
-          char str[256] = { 0 };
-          size_t n;
+			xsnprintf(buf, "REQUIRED(\n");
+			for (ss = node->u.required; ss != NULL; ss = ss->next) {
+				char str[256] = {0};
+				size_t n;
 
-          n = ss->str.len;
-          if (n < sizeof str) {
-            memcpy(str, ss->str.s, n);
-          } else {
-            memcpy(str, ss->str.s, sizeof str - 4);
-            memcpy(str + sizeof str - 4, "...", 4);
-          }
+				n = ss->str.len;
+				if (n < sizeof str) {
+					memcpy(str, ss->str.s, n);
+				} else {
+					memcpy(str, ss->str.s, sizeof str - 4);
+					memcpy(str + sizeof str - 4, "...", 4);
+				}
 
-          add_indent(buf, indent+2);
-          xsnprintf(buf,"\"%s\"%s\n", str, (ss->next != NULL) ? "," : "");
-        }
-        add_indent(buf, indent);
-        xsnprintf(buf,")");
-      }
-      break;
+				add_indent(buf, indent + 2);
+				xsnprintf(buf, "\"%s\"%s\n", str, (ss->next != NULL) ? "," : "");
+			}
+			add_indent(buf, indent);
+			xsnprintf(buf, ")");
+		}
+		break;
 
-    case JVST_CNODE_NOT:
-    case JVST_CNODE_STR_MATCH:
-    case JVST_CNODE_ARR_ITEM:
-    case JVST_CNODE_ARR_ADDITIONAL:
-    case JVST_CNODE_ARR_UNIQUE:
-      fprintf(stderr, "**not implemented**\n");
-      abort();
-  }
+	case JVST_CNODE_NOT:
+	case JVST_CNODE_STR_MATCH:
+	case JVST_CNODE_ARR_ITEM:
+	case JVST_CNODE_ARR_ADDITIONAL:
+	case JVST_CNODE_ARR_UNIQUE:
+		fprintf(stderr, "**not implemented**\n");
+		abort();
+	}
 }
 
-int jvst_cnode_dump(struct jvst_cnode *node, char *buf, size_t nb);
+int
+jvst_cnode_dump(struct jvst_cnode *node, char *buf, size_t nb);
 
-void jvst_cnode_print(struct jvst_cnode *node)
+void
+jvst_cnode_print(struct jvst_cnode *node)
 {
-  // FIXME: gross hack
-  char buf[65536] = { 0 };  // 64K
+	// FIXME: gross hack
+	char buf[65536] = {0}; // 64K
 
-  jvst_cnode_dump(node, buf, sizeof buf);
-  fprintf(stderr, "%s\n", buf);
+	jvst_cnode_dump(node, buf, sizeof buf);
+	fprintf(stderr, "%s\n", buf);
 }
 
-int jvst_cnode_dump(struct jvst_cnode *node, char *buf, size_t nb)
+int
+jvst_cnode_dump(struct jvst_cnode *node, char *buf, size_t nb)
 {
-  struct sbuf b = {
-    .buf = buf,
-    .cap = nb,
-    .len = 0,
-    .np = 0,
-  };
+	struct sbuf b = {
+	    .buf = buf, .cap = nb, .len = 0, .np = 0,
+	};
 
-  jvst_cnode_dump_inner(node, &b, 0);
-  return (b.len < b.cap) ? 0 : -1;
+	jvst_cnode_dump_inner(node, &b, 0);
+	return (b.len < b.cap) ? 0 : -1;
 }
 
 // Translates the AST into a contraint tree and optimizes the constraint
 // tree
-struct jvst_cnode *jvst_cnode_from_ast(struct ast_schema *ast);
+struct jvst_cnode *
+jvst_cnode_from_ast(struct ast_schema *ast);
 
 // Just do a raw translation without doing any optimization of the
 // constraint tree
-struct jvst_cnode *jvst_cnode_translate_ast(struct ast_schema *ast)
+struct jvst_cnode *
+jvst_cnode_translate_ast(struct ast_schema *ast)
 {
-  struct jvst_cnode *node;
-  enum json_valuetype types;
+	struct jvst_cnode *node;
+	enum json_valuetype types;
 
-  assert(ast != NULL);
-  types = ast->types;
+	assert(ast != NULL);
+	types = ast->types;
 
-  // TODO - implement ast->some_of.set != NULL logic
-  // top is a switch
-  if (types == 0) {
-    node = cnode_new_switch(true);
-  } else {
-    struct jvst_cnode *valid;
+	// TODO - implement ast->some_of.set != NULL logic
+	// top is a switch
+	if (types == 0) {
+		node = cnode_new_switch(true);
+	} else {
+		struct jvst_cnode *valid;
 
-    node = cnode_new_switch(false);
-    valid = jvst_cnode_alloc(JVST_CNODE_VALID);
+		node  = cnode_new_switch(false);
+		valid = jvst_cnode_alloc(JVST_CNODE_VALID);
 
-    if (types & JSON_VALUE_OBJECT) {
-      node->u.sw[SJP_OBJECT_BEG] = valid;
-    }
+		if (types & JSON_VALUE_OBJECT) {
+			node->u.sw[SJP_OBJECT_BEG] = valid;
+		}
 
-    if (types & JSON_VALUE_ARRAY) {
-      node->u.sw[SJP_ARRAY_BEG] = valid;
-    }
+		if (types & JSON_VALUE_ARRAY) {
+			node->u.sw[SJP_ARRAY_BEG] = valid;
+		}
 
-    if (types & JSON_VALUE_STRING) {
-      node->u.sw[SJP_STRING] = valid;
-    }
+		if (types & JSON_VALUE_STRING) {
+			node->u.sw[SJP_STRING] = valid;
+		}
 
-    if (types & JSON_VALUE_STRING) {
-      node->u.sw[SJP_STRING] = valid;
-    }
+		if (types & JSON_VALUE_STRING) {
+			node->u.sw[SJP_STRING] = valid;
+		}
 
-    if (types & JSON_VALUE_NUMBER) {
-      node->u.sw[SJP_NUMBER] = valid;
-    }
+		if (types & JSON_VALUE_NUMBER) {
+			node->u.sw[SJP_NUMBER] = valid;
+		}
 
-    if (types & JSON_VALUE_INTEGER) {
-      node->u.sw[SJP_NUMBER] = jvst_cnode_alloc(JVST_CNODE_NUM_INTEGER);
-    }
+		if (types & JSON_VALUE_INTEGER) {
+			node->u.sw[SJP_NUMBER] = jvst_cnode_alloc(JVST_CNODE_NUM_INTEGER);
+		}
 
-    if (types & JSON_VALUE_BOOL) {
-      node->u.sw[SJP_TRUE] = valid;
-      node->u.sw[SJP_FALSE] = valid;
-    }
+		if (types & JSON_VALUE_BOOL) {
+			node->u.sw[SJP_TRUE]  = valid;
+			node->u.sw[SJP_FALSE] = valid;
+		}
 
-    if (types & JSON_VALUE_NULL) {
-      node->u.sw[SJP_NULL] = valid;
-    }
-  }
+		if (types & JSON_VALUE_NULL) {
+			node->u.sw[SJP_NULL] = valid;
+		}
+	}
 
-  if (ast->kws & (KWS_MINIMUM|KWS_MAXIMUM)) {
-    enum jvst_cnode_rangeflags flags = 0;
-    double min = 0, max = 0;
-    struct jvst_cnode *range, *jxn;
+	if (ast->kws & (KWS_MINIMUM | KWS_MAXIMUM)) {
+		enum jvst_cnode_rangeflags flags = 0;
+		double min = 0, max = 0;
+		struct jvst_cnode *range, *jxn;
 
-    if (ast->kws & KWS_MINIMUM) {
-      flags |= (ast->exclusive_minimum ? JVST_CNODE_RANGE_EXCL_MIN : JVST_CNODE_RANGE_MIN);
-      min = ast->minimum;
-    }
+		if (ast->kws & KWS_MINIMUM) {
+			flags |= (ast->exclusive_minimum ? JVST_CNODE_RANGE_EXCL_MIN
+							 : JVST_CNODE_RANGE_MIN);
+			min = ast->minimum;
+		}
 
-    if (ast->kws & KWS_MAXIMUM) {
-      flags |= (ast->exclusive_maximum ? JVST_CNODE_RANGE_EXCL_MAX : JVST_CNODE_RANGE_MAX);
-      max = ast->maximum;
-    }
+		if (ast->kws & KWS_MAXIMUM) {
+			flags |= (ast->exclusive_maximum ? JVST_CNODE_RANGE_EXCL_MAX
+							 : JVST_CNODE_RANGE_MAX);
+			max = ast->maximum;
+		}
 
-    range = jvst_cnode_alloc(JVST_CNODE_NUM_RANGE);
-    range->u.num_range.flags = flags;
-    range->u.num_range.min = min;
-    range->u.num_range.max = max;
+		range = jvst_cnode_alloc(JVST_CNODE_NUM_RANGE);
+		range->u.num_range.flags = flags;
+		range->u.num_range.min = min;
+		range->u.num_range.max = max;
 
-    jxn = jvst_cnode_alloc(JVST_CNODE_AND);
-    jxn->u.ctrl = range;
-    range->next = node->u.sw[SJP_NUMBER];
-    node->u.sw[SJP_NUMBER] = jxn;
-  }
+		jxn = jvst_cnode_alloc(JVST_CNODE_AND);
+		jxn->u.ctrl = range;
+		range->next = node->u.sw[SJP_NUMBER];
+		node->u.sw[SJP_NUMBER] = jxn;
+	}
 
-  if (ast->properties.set != NULL) {
-    struct jvst_cnode **plist, *phead, *prop_set, *top_jxn;
-    struct ast_property_schema *pset;
+	if (ast->properties.set != NULL) {
+		struct jvst_cnode **plist, *phead, *prop_set, *top_jxn;
+		struct ast_property_schema *pset;
 
-    top_jxn = prop_set = phead = NULL;
-    plist = &phead;
+		top_jxn = NULL;
+		prop_set = NULL;
+		phead = NULL;
+		plist = &phead;
 
-    for(pset = ast->properties.set; pset != NULL; pset = pset->next) {
-      struct jvst_cnode *pnode;
-      pnode = jvst_cnode_alloc(JVST_CNODE_OBJ_PROP_MATCH);
-      pnode->u.prop_match.match = pset->pattern;
-      pnode->u.prop_match.constraint = jvst_cnode_translate_ast(pset->schema);
-      *plist = pnode;
-      plist = &pnode->next;
-    }
+		for (pset = ast->properties.set; pset != NULL; pset = pset->next) {
+			struct jvst_cnode *pnode;
+			pnode = jvst_cnode_alloc(JVST_CNODE_OBJ_PROP_MATCH);
+			pnode->u.prop_match.match = pset->pattern;
+			pnode->u.prop_match.constraint = jvst_cnode_translate_ast(pset->schema);
+			*plist = pnode;
+			plist = &pnode->next;
+		}
 
-    prop_set = jvst_cnode_alloc(JVST_CNODE_OBJ_PROP_SET);
-    prop_set->u.prop_set = phead;
-    assert(phead != NULL);
+		prop_set = jvst_cnode_alloc(JVST_CNODE_OBJ_PROP_SET);
+		prop_set->u.prop_set = phead;
+		assert(phead != NULL);
 
-    top_jxn = jvst_cnode_alloc(JVST_CNODE_AND);
-    top_jxn->u.ctrl = prop_set;
-    prop_set->next = node->u.sw[SJP_OBJECT_BEG];
+		top_jxn		= jvst_cnode_alloc(JVST_CNODE_AND);
+		top_jxn->u.ctrl = prop_set;
+		prop_set->next  = node->u.sw[SJP_OBJECT_BEG];
 
-    node->u.sw[SJP_OBJECT_BEG] = top_jxn;
-  }
+		node->u.sw[SJP_OBJECT_BEG] = top_jxn;
+	}
 
-  if (ast->kws & KWS_MINMAX_PROPERTIES) {
-    struct jvst_cnode *range, *jxn;
+	if (ast->kws & KWS_MINMAX_PROPERTIES) {
+		struct jvst_cnode *range, *jxn;
 
-    range = jvst_cnode_alloc(JVST_CNODE_COUNT_RANGE);
-    range->u.counts.min = ast->min_properties;
-    range->u.counts.max = ast->max_properties;
+		range = jvst_cnode_alloc(JVST_CNODE_COUNT_RANGE);
+		range->u.counts.min = ast->min_properties;
+		range->u.counts.max = ast->max_properties;
 
-    jxn = jvst_cnode_alloc(JVST_CNODE_AND);
-    jxn->u.ctrl = range;
-    range->next = node->u.sw[SJP_OBJECT_BEG];
-    node->u.sw[SJP_OBJECT_BEG] = jxn;
-  }
+		jxn = jvst_cnode_alloc(JVST_CNODE_AND);
+		jxn->u.ctrl = range;
+		range->next = node->u.sw[SJP_OBJECT_BEG];
+		node->u.sw[SJP_OBJECT_BEG] = jxn;
+	}
 
-  if (ast->required.set != NULL) {
-    struct jvst_cnode *req, *jxn;
+	if (ast->required.set != NULL) {
+		struct jvst_cnode *req, *jxn;
 
-    req = jvst_cnode_alloc(JVST_CNODE_OBJ_REQUIRED);
-    req->u.required = ast->required.set;
+		req = jvst_cnode_alloc(JVST_CNODE_OBJ_REQUIRED);
+		req->u.required = ast->required.set;
 
-    jxn = jvst_cnode_alloc(JVST_CNODE_AND);
-    jxn->u.ctrl = req;
-    req->next = node->u.sw[SJP_OBJECT_BEG];
-    node->u.sw[SJP_OBJECT_BEG] = jxn;
-  }
+		jxn = jvst_cnode_alloc(JVST_CNODE_AND);
+		jxn->u.ctrl = req;
+		req->next = node->u.sw[SJP_OBJECT_BEG];
+		node->u.sw[SJP_OBJECT_BEG] = jxn;
+	}
 
-  if (ast->dependencies_strings.set != NULL) {
-    struct ast_property_names *pnames;
-    struct jvst_cnode *top_jxn, **tpp;
+	if (ast->dependencies_strings.set != NULL) {
+		struct ast_property_names *pnames;
+		struct jvst_cnode *top_jxn, **tpp;
 
-    top_jxn = jvst_cnode_alloc(JVST_CNODE_AND);
-    top_jxn->u.ctrl = NULL;
-    tpp = &top_jxn->u.ctrl;
+		top_jxn = jvst_cnode_alloc(JVST_CNODE_AND);
+		top_jxn->u.ctrl = NULL;
+		tpp = &top_jxn->u.ctrl;
 
-    for (pnames = ast->dependencies_strings.set; pnames != NULL; pnames = pnames->next) {
-      struct jvst_cnode *req, *pset, *pm, *jxn;
-      struct ast_string_set *strset;
+		for (pnames = ast->dependencies_strings.set; pnames != NULL;
+		     pnames = pnames->next) {
+			struct jvst_cnode *req, *pset, *pm, *jxn;
+			struct ast_string_set *strset;
 
-      req = jvst_cnode_alloc(JVST_CNODE_OBJ_REQUIRED);
-      // build required stringset for the dependency pair
-      assert(pnames->pattern.dialect == RE_LITERAL);
-      req->u.required = cnode_strset(pnames->pattern.str, 
-          cnode_strset_copy(pnames->set));
+			req = jvst_cnode_alloc(JVST_CNODE_OBJ_REQUIRED);
+			// build required stringset for the dependency pair
+			assert(pnames->pattern.dialect == RE_LITERAL);
+			req->u.required = cnode_strset(pnames->pattern.str, cnode_strset_copy(pnames->set));
 
-      pm = jvst_cnode_alloc(JVST_CNODE_OBJ_PROP_MATCH);
-      pm->u.prop_match.match = pnames->pattern;
-      pm->u.prop_match.constraint = jvst_cnode_alloc(JVST_CNODE_INVALID);
+			pm = jvst_cnode_alloc(JVST_CNODE_OBJ_PROP_MATCH);
+			pm->u.prop_match.match = pnames->pattern;
+			pm->u.prop_match.constraint = jvst_cnode_alloc(JVST_CNODE_INVALID);
 
-      pset = jvst_cnode_alloc(JVST_CNODE_OBJ_PROP_SET);
-      pset->u.prop_set = pm;
+			pset = jvst_cnode_alloc(JVST_CNODE_OBJ_PROP_SET);
+			pset->u.prop_set = pm;
 
-      req->next = pset;
-      jxn = jvst_cnode_alloc(JVST_CNODE_OR);
-      jxn->u.ctrl = req;
+			req->next = pset;
+			jxn = jvst_cnode_alloc(JVST_CNODE_OR);
+			jxn->u.ctrl = req;
 
-      *tpp = jxn;
-      tpp = &jxn->next;
-    }
+			*tpp = jxn;
+			tpp  = &jxn->next;
+		}
 
-    *tpp = node->u.sw[SJP_OBJECT_BEG];
-    node->u.sw[SJP_OBJECT_BEG] = top_jxn;
-  }
+		*tpp = node->u.sw[SJP_OBJECT_BEG];
+		node->u.sw[SJP_OBJECT_BEG] = top_jxn;
+	}
 
-  if (ast->dependencies_schema.set != NULL) {
-    struct ast_property_schema *pschema;
-    struct jvst_cnode *top_jxn, **tpp;
+	if (ast->dependencies_schema.set != NULL) {
+		struct ast_property_schema *pschema;
+		struct jvst_cnode *top_jxn, **tpp;
 
-    top_jxn = jvst_cnode_alloc(JVST_CNODE_AND);
-    top_jxn->u.ctrl = node;
-    tpp = &node->next;
-    node = top_jxn;
+		top_jxn = jvst_cnode_alloc(JVST_CNODE_AND);
+		top_jxn->u.ctrl = node;
+		tpp = &node->next;
+		node = top_jxn;
 
-    for (pschema = ast->dependencies_schema.set; pschema != NULL; pschema = pschema->next) {
-      struct jvst_cnode *jxn, **jpp;
-      struct jvst_cnode *sw, *req, *schema, *andjxn, *pm, *pset;
-      struct ast_string_set *strset;
+		for (pschema = ast->dependencies_schema.set; pschema != NULL;
+		     pschema = pschema->next) {
+			struct jvst_cnode *jxn, **jpp;
+			struct jvst_cnode *sw, *req, *schema, *andjxn, *pm, *pset;
+			struct ast_string_set *strset;
 
-      jxn = jvst_cnode_alloc(JVST_CNODE_OR);
-      jpp = &jxn->u.ctrl;
-      *jpp = NULL;
+			jxn  = jvst_cnode_alloc(JVST_CNODE_OR);
+			jpp  = &jxn->u.ctrl;
+			*jpp = NULL;
 
-      andjxn = jvst_cnode_alloc(JVST_CNODE_AND);
+			andjxn = jvst_cnode_alloc(JVST_CNODE_AND);
 
-      req = jvst_cnode_alloc(JVST_CNODE_OBJ_REQUIRED);
-      // build required stringset for the dependency pair
-      assert(pschema->pattern.dialect == RE_LITERAL);
-      req->u.required = cnode_strset(pschema->pattern.str, NULL);
+			req = jvst_cnode_alloc(JVST_CNODE_OBJ_REQUIRED);
+			// build required stringset for the dependency pair
+			assert(pschema->pattern.dialect == RE_LITERAL);
+			req->u.required = cnode_strset(pschema->pattern.str, NULL);
 
-      sw = cnode_new_switch(false);
-      sw->u.sw[SJP_OBJECT_BEG] = req;
-      andjxn->u.ctrl = sw;
-      sw->next = jvst_cnode_translate_ast(pschema->schema);
+			sw = cnode_new_switch(false);
+			sw->u.sw[SJP_OBJECT_BEG] = req;
+			andjxn->u.ctrl = sw;
+			sw->next = jvst_cnode_translate_ast(pschema->schema);
 
-      *jpp = andjxn;
-      jpp = &(*jpp)->next;
+			*jpp = andjxn;
+			jpp  = &(*jpp)->next;
 
-      sw = cnode_new_switch(true);
+			sw = cnode_new_switch(true);
 
-      pm = jvst_cnode_alloc(JVST_CNODE_OBJ_PROP_MATCH);
-      pm->u.prop_match.match = pschema->pattern;
-      pm->u.prop_match.constraint = jvst_cnode_alloc(JVST_CNODE_INVALID);
+			pm = jvst_cnode_alloc(JVST_CNODE_OBJ_PROP_MATCH);
+			pm->u.prop_match.match = pschema->pattern;
+			pm->u.prop_match.constraint = jvst_cnode_alloc(JVST_CNODE_INVALID);
 
-      pset = jvst_cnode_alloc(JVST_CNODE_OBJ_PROP_SET);
-      pset->u.prop_set = pm;
+			pset = jvst_cnode_alloc(JVST_CNODE_OBJ_PROP_SET);
+			pset->u.prop_set = pm;
 
-      sw->u.sw[SJP_OBJECT_BEG] = pset;
+			sw->u.sw[SJP_OBJECT_BEG] = pset;
 
-      *jpp = sw;
-      jpp = &(*jpp)->next;
+			*jpp = sw;
+			jpp  = &(*jpp)->next;
 
-      *tpp = jxn;
-      tpp = &jxn->next;
-    }
-  }
+			*tpp = jxn;
+			tpp  = &jxn->next;
+		}
+	}
 
-  if (ast->some_of.set != NULL) {
-    struct jvst_cnode *top_jxn, *some_jxn, **conds;
-    struct ast_schema_set *sset;
-    enum jvst_cnode_type op = JVST_CNODE_OR;
+	if (ast->some_of.set != NULL) {
+		struct jvst_cnode *top_jxn, *some_jxn, **conds;
+		struct ast_schema_set *sset;
+		enum jvst_cnode_type op = JVST_CNODE_OR;
 
-    if (ast->some_of.min == ast->some_of.max) {
-      op = (ast->some_of.min == 1) ? JVST_CNODE_XOR : JVST_CNODE_AND;
-    }
+		if (ast->some_of.min == ast->some_of.max) {
+			op = (ast->some_of.min == 1) ? JVST_CNODE_XOR : JVST_CNODE_AND;
+		}
 
-    some_jxn = jvst_cnode_alloc(op);
-    conds = &some_jxn->u.ctrl;
-    some_jxn->u.ctrl = NULL;
-    for (sset = ast->some_of.set; sset != NULL; sset = sset->next) {
-      struct jvst_cnode *c;
-      c = jvst_cnode_translate_ast(sset->schema);
-      *conds = c;
-      conds = &c->next;
-    }
+		some_jxn = jvst_cnode_alloc(op);
+		conds = &some_jxn->u.ctrl;
+		some_jxn->u.ctrl = NULL;
+		for (sset = ast->some_of.set; sset != NULL; sset = sset->next) {
+			struct jvst_cnode *c;
+			c = jvst_cnode_translate_ast(sset->schema);
+			*conds = c;
+			conds = &c->next;
+		}
 
-    top_jxn = jvst_cnode_alloc(JVST_CNODE_AND);
-    top_jxn->u.ctrl = some_jxn;
-    some_jxn->next = node;
-    node = top_jxn;
-  }
+		top_jxn = jvst_cnode_alloc(JVST_CNODE_AND);
+		top_jxn->u.ctrl = some_jxn;
+		some_jxn->next = node;
+		node = top_jxn;
+	}
 
-  return node;
+	return node;
 }
 
-static struct jvst_cnode *cnode_deep_copy(struct jvst_cnode *node)
+static struct jvst_cnode *
+cnode_deep_copy(struct jvst_cnode *node)
 {
-  struct jvst_cnode *tree;
+	struct jvst_cnode *tree;
 
-  switch (node->type) {
-    case JVST_CNODE_INVALID:
-    case JVST_CNODE_VALID:
-    case JVST_CNODE_NUM_INTEGER:
-    case JVST_CNODE_ARR_UNIQUE:
-      return jvst_cnode_alloc(node->type);
+	switch (node->type) {
+	case JVST_CNODE_INVALID:
+	case JVST_CNODE_VALID:
+	case JVST_CNODE_NUM_INTEGER:
+	case JVST_CNODE_ARR_UNIQUE:
+		return jvst_cnode_alloc(node->type);
 
-    case JVST_CNODE_AND:
-    case JVST_CNODE_OR:
-    case JVST_CNODE_XOR:
-    case JVST_CNODE_NOT:
-      {
-        struct jvst_cnode *ctrl, **cp;
-        tree = jvst_cnode_alloc(node->type);
-        cp = &tree->u.ctrl;
-        for (ctrl=node->u.ctrl; ctrl != NULL; ctrl = ctrl->next) {
-          *cp = cnode_deep_copy(ctrl);
-          cp = &(*cp)->next;
-        }
-        return tree;
-      }
+	case JVST_CNODE_AND:
+	case JVST_CNODE_OR:
+	case JVST_CNODE_XOR:
+	case JVST_CNODE_NOT:
+		{
+			struct jvst_cnode *ctrl, **cp;
+			tree = jvst_cnode_alloc(node->type);
+			cp = &tree->u.ctrl;
+			for (ctrl = node->u.ctrl; ctrl != NULL; ctrl = ctrl->next) {
+				*cp = cnode_deep_copy(ctrl);
+				cp = &(*cp)->next;
+			}
+			return tree;
+		}
 
-    case JVST_CNODE_SWITCH:
-      {
-        size_t i,n;
-        tree = jvst_cnode_alloc(node->type);
-        for (i=0,n=ARRAYLEN(node->u.sw); i < n; i++) {
-          tree->u.sw[i] = NULL;
-          if (node->u.sw[i] != NULL) {
-            tree->u.sw[i] = cnode_deep_copy(node->u.sw[i]);
-          }
-        }
-        return tree;
-      }
+	case JVST_CNODE_SWITCH:
+		{
+			size_t i, n;
+			tree = jvst_cnode_alloc(node->type);
+			for (i = 0, n = ARRAYLEN(node->u.sw); i < n; i++) {
+				tree->u.sw[i] = NULL;
+				if (node->u.sw[i] != NULL) {
+					tree->u.sw[i] = cnode_deep_copy(node->u.sw[i]);
+				}
+			}
+			return tree;
+		}
 
-    case JVST_CNODE_NUM_RANGE:
-      tree = jvst_cnode_alloc(node->type);
-      tree->u.num_range = node->u.num_range;
-      return tree;
+	case JVST_CNODE_NUM_RANGE:
+		tree = jvst_cnode_alloc(node->type);
+		tree->u.num_range = node->u.num_range;
+		return tree;
 
-    case JVST_CNODE_COUNT_RANGE:
-      tree = jvst_cnode_alloc(node->type);
-      tree->u.counts = node->u.counts;
-      return tree;
+	case JVST_CNODE_COUNT_RANGE:
+		tree	   = jvst_cnode_alloc(node->type);
+		tree->u.counts = node->u.counts;
+		return tree;
 
-    case JVST_CNODE_STR_MATCH:
-      tree = jvst_cnode_alloc(node->type);
-      tree->u.str_match = node->u.str_match;
-      return tree;
+	case JVST_CNODE_STR_MATCH:
+		tree = jvst_cnode_alloc(node->type);
+		tree->u.str_match = node->u.str_match;
+		return tree;
 
-    case JVST_CNODE_OBJ_PROP_SET:
-      {
-        struct jvst_cnode *prop, **pp;
-        tree = jvst_cnode_alloc(node->type);
-        pp = &tree->u.prop_set;
-        for (prop=node->u.prop_set; prop != NULL; prop = prop->next) {
-          *pp = cnode_deep_copy(prop);
-          pp = &(*pp)->next;
-        }
-        return tree;
-      }
+	case JVST_CNODE_OBJ_PROP_SET:
+		{
+			struct jvst_cnode *prop, **pp;
+			tree = jvst_cnode_alloc(node->type);
+			pp = &tree->u.prop_set;
+			for (prop = node->u.prop_set; prop != NULL; prop = prop->next) {
+				*pp = cnode_deep_copy(prop);
+				pp  = &(*pp)->next;
+			}
+			return tree;
+		}
 
-    case JVST_CNODE_OBJ_PROP_MATCH:
-      tree = jvst_cnode_alloc(node->type);
-      tree->u.prop_match.match = node->u.prop_match.match;
-      tree->u.prop_match.constraint = cnode_deep_copy(node->u.prop_match.constraint);
-      return tree;
+	case JVST_CNODE_OBJ_PROP_MATCH:
+		tree = jvst_cnode_alloc(node->type);
+		tree->u.prop_match.match = node->u.prop_match.match;
+		tree->u.prop_match.constraint = cnode_deep_copy(node->u.prop_match.constraint);
+		return tree;
 
-    case JVST_CNODE_OBJ_REQUIRED:
-      tree = jvst_cnode_alloc(node->type);
-      tree->u.required = node->u.required;
-      return tree;
+	case JVST_CNODE_OBJ_REQUIRED:
+		tree = jvst_cnode_alloc(node->type);
+		tree->u.required = node->u.required;
+		return tree;
 
-    case JVST_CNODE_ARR_ITEM:
-      {
-        struct jvst_cnode *item, **ip;
-        tree = jvst_cnode_alloc(node->type);
-        ip = &tree->u.arr_item;
-        for (item=node->u.arr_item; item != NULL; item = item->next) {
-          *ip = cnode_deep_copy(item);
-          ip = &(*ip)->next;
-        }
-        return tree;
-      }
+	case JVST_CNODE_ARR_ITEM:
+		{
+			struct jvst_cnode *item, **ip;
+			tree = jvst_cnode_alloc(node->type);
+			ip = &tree->u.arr_item;
+			for (item = node->u.arr_item; item != NULL; item = item->next) {
+				*ip = cnode_deep_copy(item);
+				ip  = &(*ip)->next;
+			}
+			return tree;
+		}
 
-    case JVST_CNODE_ARR_ADDITIONAL:
-      tree = jvst_cnode_alloc(node->type);
-      tree->u.arr_item = cnode_deep_copy(node->u.arr_item);
-      return tree;
+	case JVST_CNODE_ARR_ADDITIONAL:
+		tree = jvst_cnode_alloc(node->type);
+		tree->u.arr_item = cnode_deep_copy(node->u.arr_item);
+		return tree;
 
-    default:
-      SHOULD_NOT_REACH();
-  }
+	default:
+		SHOULD_NOT_REACH();
+	}
 
-  // now free the node
-  jvst_cnode_free(node);
+	// now free the node
+	jvst_cnode_free(node);
 }
 
-struct jvst_cnode *cnode_list_end(struct jvst_cnode *node)
+struct jvst_cnode *
+cnode_list_end(struct jvst_cnode *node)
 {
-  assert(node != NULL);
-  while (node->next != NULL) {
-    node = node->next;
-  }
-  return node;
+	assert(node != NULL);
+	while (node->next != NULL) {
+		node = node->next;
+	}
+	return node;
 }
 
-struct jvst_cnode *cnode_list_prepend(struct jvst_cnode **headp, struct jvst_cnode *node)
+struct jvst_cnode *
+cnode_list_prepend(struct jvst_cnode **headp, struct jvst_cnode *node)
 {
-  assert(headp != NULL);
-  node->next = *headp;
-  *headp = node;
-  return node;
+	assert(headp != NULL);
+	node->next = *headp;
+	*headp = node;
+	return node;
 }
 
-struct jvst_cnode *cnode_list_concat(struct jvst_cnode **headp, struct jvst_cnode *tail)
+struct jvst_cnode *
+cnode_list_concat(struct jvst_cnode **headp, struct jvst_cnode *tail)
 {
-  struct jvst_cnode **hp0;
+	struct jvst_cnode **hp0;
 
-  hp0 = headp;
+	hp0 = headp;
 
-  assert(headp != NULL);
-  while (*headp != NULL) {
-    headp = &(*headp)->next;
-  }
-  *headp = tail;
-  return *hp0;
+	assert(headp != NULL);
+	while (*headp != NULL) {
+		headp = &(*headp)->next;
+	}
+	*headp = tail;
+	return *hp0;
 }
 
-static struct jvst_cnode *cnode_find_type(struct jvst_cnode *node, enum jvst_cnode_type type)
+static struct jvst_cnode *
+cnode_find_type(struct jvst_cnode *node, enum jvst_cnode_type type)
 {
-  for(; node != NULL; node = node->next) {
-    if (node->type == type) {
-      return node;
-    }
-  }
+	for (; node != NULL; node = node->next) {
+		if (node->type == type) {
+			return node;
+		}
+	}
 
-  return NULL;
+	return NULL;
 }
 
-static struct jvst_cnode *cnode_optimize_andor_switches(struct jvst_cnode *top)
+static struct jvst_cnode *
+cnode_optimize_andor_switches(struct jvst_cnode *top)
 {
-  // check if all nodes are SWITCH nodes.  If they are, combine
-  // the switch clauses and simplify
+	// check if all nodes are SWITCH nodes.  If they are, combine
+	// the switch clauses and simplify
 
-  struct jvst_cnode *node, **pp, *sw;
-  size_t i,n;
+	struct jvst_cnode *node, **pp, *sw;
+	size_t i, n;
 
-  for(node=top->u.ctrl; node != NULL; node = node->next) {
-    if (node->type != JVST_CNODE_SWITCH) {
-      return top;
-    }
-  }
+	for (node = top->u.ctrl; node != NULL; node = node->next) {
+		if (node->type != JVST_CNODE_SWITCH) {
+			return top;
+		}
+	}
 
-  // all nodes are switch nodes...
-  sw = jvst_cnode_alloc(JVST_CNODE_SWITCH);
-  for (i=0, n=ARRAYLEN(sw->u.sw); i < n; i++) {
-    struct jvst_cnode *jxn, **cpp;
+	// all nodes are switch nodes...
+	sw = jvst_cnode_alloc(JVST_CNODE_SWITCH);
+	for (i = 0, n = ARRAYLEN(sw->u.sw); i < n; i++) {
+		struct jvst_cnode *jxn, **cpp;
 
-    jxn = jvst_cnode_alloc(top->type);
-    cpp = &jxn->u.ctrl;
+		jxn = jvst_cnode_alloc(top->type);
+		cpp = &jxn->u.ctrl;
 
-    for(node=top->u.ctrl; node != NULL; node = node->next) {
-      assert(node->type == JVST_CNODE_SWITCH);
+		for (node = top->u.ctrl; node != NULL; node = node->next) {
+			assert(node->type == JVST_CNODE_SWITCH);
 
-      *cpp = node->u.sw[i];
-      assert( (*cpp)->next == NULL );
-      cpp = &(*cpp)->next;
-    }
+			*cpp = node->u.sw[i];
+			assert((*cpp)->next == NULL);
+			cpp = &(*cpp)->next;
+		}
 
-    sw->u.sw[i] = jvst_cnode_optimize(jxn);
-  }
+		sw->u.sw[i] = jvst_cnode_optimize(jxn);
+	}
 
-  return sw;
+	return sw;
 }
 
-static struct jvst_cnode *cnode_optimize_andor(struct jvst_cnode *top)
+static struct jvst_cnode *
+cnode_optimize_andor(struct jvst_cnode *top)
 {
-  struct jvst_cnode *node, *next, **pp;
-  pp = &top->u.ctrl;
+	struct jvst_cnode *node, *next, **pp;
+	pp = &top->u.ctrl;
 
-  // first optimize child nodes...
-  for(node=top->u.ctrl; node != NULL; node = next) {
-    next = node->next;
-    *pp = jvst_cnode_optimize(node);
-    pp = &(*pp)->next;
-  }
+	// first optimize child nodes...
+	for (node = top->u.ctrl; node != NULL; node = next) {
+		next = node->next;
+		*pp  = jvst_cnode_optimize(node);
+		pp   = &(*pp)->next;
+	}
 
-  // pass 1: remove VALID/INVALID nodes
-  switch (top->type) {
-    case JVST_CNODE_AND:
-      for(pp = &top->u.ctrl; *pp != NULL;) {
-        switch ((*pp)->type) {
-          case JVST_CNODE_INVALID:
-            // whole AND becomes invalid
-            (*pp)->next = NULL;
-            return *pp;
+	// pass 1: remove VALID/INVALID nodes
+	switch (top->type) {
+	case JVST_CNODE_AND:
+		for (pp = &top->u.ctrl; *pp != NULL;) {
+			switch ((*pp)->type) {
+			case JVST_CNODE_INVALID:
+				// whole AND becomes invalid
+				(*pp)->next = NULL;
+				return *pp;
 
-          case JVST_CNODE_VALID:
-            // can eliminate VALID from AND
-            *pp = (*pp)->next;
-            continue;
+			case JVST_CNODE_VALID:
+				// can eliminate VALID from AND
+				*pp = (*pp)->next;
+				continue;
 
-          default:
-            break;
-        }
+			default:
+				break;
+			}
 
-        pp = &(*pp)->next;
-      }
+			pp = &(*pp)->next;
+		}
 
-      // all nodes were valid
-      if (top->u.ctrl == NULL) {
-        return jvst_cnode_alloc(JVST_CNODE_VALID);
-      }
-      break;
+		// all nodes were valid
+		if (top->u.ctrl == NULL) {
+			return jvst_cnode_alloc(JVST_CNODE_VALID);
+		}
+		break;
 
-    case JVST_CNODE_OR:
-      for(pp = &top->u.ctrl; *pp != NULL;) {
-        switch ((*pp)->type) {
-          case JVST_CNODE_VALID:
-            // whole OR becomes valid
-            (*pp)->next = NULL;
-            return *pp;
+	case JVST_CNODE_OR:
+		for (pp = &top->u.ctrl; *pp != NULL;) {
+			switch ((*pp)->type) {
+			case JVST_CNODE_VALID:
+				// whole OR becomes valid
+				(*pp)->next = NULL;
+				return *pp;
 
-          case JVST_CNODE_INVALID:
-            // can eliminate INVALID from OR
-            *pp = (*pp)->next;
-            continue;
+			case JVST_CNODE_INVALID:
+				// can eliminate INVALID from OR
+				*pp = (*pp)->next;
+				continue;
 
-          default:
-            break;
-        }
+			default:
+				break;
+			}
 
-        pp = &(*pp)->next;
-      }
+			pp = &(*pp)->next;
+		}
 
-      // all nodes were invalid
-      if (top->u.ctrl == NULL) {
-        return jvst_cnode_alloc(JVST_CNODE_INVALID);
-      }
-      break;
+		// all nodes were invalid
+		if (top->u.ctrl == NULL) {
+			return jvst_cnode_alloc(JVST_CNODE_INVALID);
+		}
+		break;
 
-    default:
-      SHOULD_NOT_REACH();
-  }
+	default:
+		SHOULD_NOT_REACH();
+	}
 
-  assert(top->u.ctrl != NULL);
-  if (top->u.ctrl->next == NULL) {
-    // only one child
-    return top->u.ctrl;
-  }
+	assert(top->u.ctrl != NULL);
+	if (top->u.ctrl->next == NULL) {
+		// only one child
+		return top->u.ctrl;
+	}
 
-  // pass 2: combine subnodes of the same type (ie: AND will combine
-  // with AND and OR will combine with OR)
-  for(pp = &top->u.ctrl; *pp != NULL; pp = &(*pp)->next) {
-    struct jvst_cnode *head, *tail;
+	// pass 2: combine subnodes of the same type (ie: AND will combine
+	// with AND and OR will combine with OR)
+	for (pp = &top->u.ctrl; *pp != NULL; pp = &(*pp)->next) {
+		struct jvst_cnode *head, *tail;
 
-    if ((*pp)->type != top->type) {
-      continue;
-    }
+		if ((*pp)->type != top->type) {
+			continue;
+		}
 
-    // save next link
-    next = (*pp)->next;
-    *pp = (*pp)->u.ctrl;
+		// save next link
+		next = (*pp)->next;
+		*pp  = (*pp)->u.ctrl;
 
-    // fast path...
-    if (next == NULL) {
-      continue;
-    }
+		// fast path...
+		if (next == NULL) {
+			continue;
+		}
 
-    while (*pp != NULL) {
-      pp = &(*pp)->next;
-    }
+		while (*pp != NULL) {
+			pp = &(*pp)->next;
+		}
 
-    *pp = next;
-  }
+		*pp = next;
+	}
 
-  return cnode_optimize_andor_switches(top);
+	return cnode_optimize_andor_switches(top);
 }
 
-struct jvst_cnode *jvst_cnode_optimize(struct jvst_cnode *tree)
+struct jvst_cnode *
+jvst_cnode_optimize(struct jvst_cnode *tree)
 {
-  struct jvst_cnode *node;
+	struct jvst_cnode *node;
 
-  // make a copy
-  tree = cnode_deep_copy(tree);
+	// make a copy
+	tree = cnode_deep_copy(tree);
 
-  switch (tree->type) {
-    case JVST_CNODE_INVALID:
-    case JVST_CNODE_VALID:
-    case JVST_CNODE_NUM_INTEGER:
-    case JVST_CNODE_ARR_UNIQUE:
-      return tree;
+	switch (tree->type) {
+	case JVST_CNODE_INVALID:
+	case JVST_CNODE_VALID:
+	case JVST_CNODE_NUM_INTEGER:
+	case JVST_CNODE_ARR_UNIQUE:
+		return tree;
 
-    case JVST_CNODE_AND:
-    case JVST_CNODE_OR:
-      return cnode_optimize_andor(tree);
+	case JVST_CNODE_AND:
+	case JVST_CNODE_OR:
+		return cnode_optimize_andor(tree);
 
-    case JVST_CNODE_XOR:
-      // TODO: basic optimization for XOR
-      return tree;
+	case JVST_CNODE_XOR:
+		// TODO: basic optimization for XOR
+		return tree;
 
-    case JVST_CNODE_NOT:
-      // TODO: basic optimizations for NOT
-      return tree;
+	case JVST_CNODE_NOT:
+		// TODO: basic optimizations for NOT
+		return tree;
 
-    case JVST_CNODE_SWITCH:
-      {
-        size_t i,n;
-        for(i=0, n=ARRAYLEN(tree->u.sw); i < n; i++) {
-          tree->u.sw[i] = jvst_cnode_optimize(tree->u.sw[i]);
-        }
-      }
-      return tree;
+	case JVST_CNODE_SWITCH:
+		{
+			size_t i, n;
+			for (i = 0, n = ARRAYLEN(tree->u.sw); i < n; i++) {
+				tree->u.sw[i] = jvst_cnode_optimize(tree->u.sw[i]);
+			}
+		}
+		return tree;
 
-    case JVST_CNODE_OBJ_PROP_SET:
-    case JVST_CNODE_NUM_RANGE:
-    case JVST_CNODE_COUNT_RANGE:
-    case JVST_CNODE_STR_MATCH:
-    case JVST_CNODE_OBJ_PROP_MATCH:
-    case JVST_CNODE_OBJ_REQUIRED:
-    case JVST_CNODE_ARR_ITEM:
-    case JVST_CNODE_ARR_ADDITIONAL:
-      // TODO: basic optimization for these nodes
-      return tree;
+	case JVST_CNODE_OBJ_PROP_SET:
+	case JVST_CNODE_NUM_RANGE:
+	case JVST_CNODE_COUNT_RANGE:
+	case JVST_CNODE_STR_MATCH:
+	case JVST_CNODE_OBJ_PROP_MATCH:
+	case JVST_CNODE_OBJ_REQUIRED:
+	case JVST_CNODE_ARR_ITEM:
+	case JVST_CNODE_ARR_ADDITIONAL:
+		// TODO: basic optimization for these nodes
+		return tree;
 
-    default:
-      SHOULD_NOT_REACH();
-  }
+	default:
+		SHOULD_NOT_REACH();
+	}
 }
 
-
-
-
+/* vim: set tabstop=8 shiftwidth=8 noexpandtab: */

--- a/src/validate_constraints.c
+++ b/src/validate_constraints.c
@@ -1,5 +1,6 @@
 #include "validate_constraints.h"
 
+#include <assert.h>
 #include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
@@ -63,6 +64,7 @@ struct jvst_cnode *jvst_cnode_alloc(enum JVST_CNODE_TYPE type)
   struct jvst_cnode *n;
   n = cnode_new();
   n->type = type;
+  n->next = NULL;
   return n;
 }
 
@@ -129,52 +131,28 @@ void jvst_cnode_free_tree(struct jvst_cnode *root)
       /* constrains with no child nodes */
       case JVST_CNODE_NUM_INTEGER:
       case JVST_CNODE_NUM_RANGE:
+      case JVST_CNODE_COUNT_RANGE:
       case JVST_CNODE_ARR_UNIQUE:
-      case JVST_CNODE_STR_LENRANGE:
-      case JVST_CNODE_OBJ_NUMPROP_RANGE:
-      case JVST_CNODE_ARR_NUMITEM_RANGE:
         break;
 
       case JVST_CNODE_STR_MATCH:
-        json_string_finalize(&node->u.str_match.pattern);
-        if (node->u.str_match.matcher) {
-          // XXX - ensure that fsm is torn down
-          // do we pool FSMs?  check if they're ref counted.
-        }
-        break;
-
-      case JVST_CNODE_STR_EQUAL:
-        json_string_finalize(&node->u.str_equal);
-        break;
-
-      case JVST_CNODE_OBJ_PROPS:
-        for (i=0, n=node->u.props.n; i < n; i++) {
-          struct jvst_cnode *child;
-
-          json_string_finalize(&node->u.props.names[i]);
-          child = &node->u.props.constraints[i];
-          if (child != NULL) {
-            jvst_cnode_free_tree(child);
-          }
-        }
+        // XXX - need to handle FSM cleanup
+        // pool FSMs?  ref count them?
+        //
+        // be lazy about it, keep references to temporaries,
+        // recreate the fsm from scratch when we're done and delete
+        // the temporaries?
         break;
 
       case JVST_CNODE_OBJ_PROP_MATCH:
-        json_string_finalize(&node->u.prop_match.pattern);
-        if (node->u.prop_match.matcher != NULL) {
-          // XXX - ensure that fsm is torn down
-          // do we pool FSMs?  check if they're ref counted.
-        }
-
-        if (node->u.prop_match.constraint != NULL) {
-          jvst_cnode_free_tree(node->u.prop_match.constraint);
-        }
+        // XXX - ensure that fsm is torn down
+        // do we pool FSMs?  check if they're ref counted.
+        assert(node->u.prop_match.constraint != NULL);
+        jvst_cnode_free_tree(node->u.prop_match.constraint);
         break;
 
-      case JVST_CNODE_OBJ_REQUIRE:
-        for (i=0, n=node->u.required.n; i < n; i++) {
-          json_string_finalize(&node->u.required.s[i]);
-        }
+      case JVST_CNODE_OBJ_REQUIRED:
+        // XXX - finalize the string set?
         break;
 
       case JVST_CNODE_ARR_ITEM:
@@ -193,134 +171,258 @@ void jvst_cnode_free_tree(struct jvst_cnode *root)
   }
 }
 
-static inline size_t xsnprintf(char *p, size_t sz, const char *fmt, ...)
-{
-  int ret;
-  va_list args;
+struct sbuf {
+  char *buf;
+  size_t cap;
+  size_t len;
+  size_t np;
+};
 
-  va_start(args, fmt);
-  if (ret = vsnprintf(p,sz,fmt,args), ret < 0) {
-    // FIXME: handle this more gracefully!
-    perror("ERROR dumping cnode to a buffer");
-    abort();
-  }
-  va_end(args);
-
-  return (size_t)ret;
-}
-
-static int add_indent(char *buf, size_t nb, int indent)
+static int add_indent(struct sbuf *buf, int indent)
 {
   int i;
   
-  for (i=0; i < indent && nb > 0; i++, nb--) {
-    buf[i] = ' ';
+  for (i=0; i < indent; i++) {
+    if (buf->len >= buf->cap) {
+      break;
+    }
+    buf->buf[buf->len++] = ' ';
   }
+
+  buf->np += indent;
 
   return indent;
 }
 
-// returns number of bytes written
-static size_t jvst_cnode_dump_inner(struct jvst_cnode *node, char *buf, size_t nb0, int indent)
+static void xsnprintf(struct sbuf *b, const char *fmt, ...)
 {
-  size_t nb,np;
+  int ret;
+  va_list args;
+  char *p;
+  size_t nb;
 
-  nb = nb0;
+  assert(b->len <= b->cap);
+
+  p = b->buf+b->len;
+  nb = b->cap - b->len;
+
+  va_start(args, fmt);
+  ret = vsnprintf(p,nb,fmt,args);
+  va_end(args);
+  if (ret < 0) {
+    // FIXME: handle this more gracefully!
+    perror("ERROR dumping cnode to a buffer");
+    abort();
+  }
+
+  if ((size_t)ret <= nb) {
+    b->len += ret;
+  } else {
+    b->len = b->cap;
+  }
+
+  b->np += ret;
+}
+
+
+
+// returns number of bytes written
+static void jvst_cnode_dump_inner(struct jvst_cnode *node, struct sbuf *buf, int indent)
+{
+  const char *op = NULL;
 
   if (node == NULL) {
-    np = xsnprintf(buf, nb, "<null>");
-    nb -= np;
-    goto finished;
+    xsnprintf(buf, "<null>");
+    return;
   }
 
   switch (node->type) {
     case JVST_CNODE_INVALID:
     case JVST_CNODE_VALID:
-      np = xsnprintf(buf, nb, (node->type == JVST_CNODE_VALID) ? "VALID" : "INVALID");
-      nb -= np;
-      goto finished;
+      xsnprintf(buf, (node->type == JVST_CNODE_VALID) ? "VALID" : "INVALID");
+      return;
 
     case JVST_CNODE_SWITCH:
       {
         size_t i,n;
 
-        if (np = xsnprintf(buf,nb, "SWITCH(\n"), np >= nb) {
-          nb -= np;
-          goto finished;
-        }
-
-        buf += np;
-        nb -= np;
-
+        xsnprintf(buf, "SWITCH(\n");
         n = ARRAYLEN(node->u.sw);
         for (i=0; i < n; i++) {
-          if (np = add_indent(buf,nb,indent+2), np >= nb) {
-            nb -= np;
-            goto finished;
+          add_indent(buf,indent+2);
+          xsnprintf(buf,"%-10s : ", evt2name(i));
+          jvst_cnode_dump_inner(node->u.sw[i], buf, indent+2);
+          if (i < n-1) {
+            xsnprintf(buf,",\n");
+          } else {
+            xsnprintf(buf,"\n");
+            add_indent(buf,indent);
+            xsnprintf(buf,")");
           }
-          buf += np;
-          nb -= np;
-
-          if (np = snprintf(buf,nb,"%-10s:", evt2name(i)), np >= nb) {
-            nb -= np;
-            goto finished;
-          }
-          buf += np;
-          nb -= np;
-
-          if (np = jvst_cnode_dump_inner(node->u.sw[i], buf, nb, indent+2), np > nb) {
-            nb -= np;
-            goto finished;
-          }
-          buf += np;
-          nb -= np;
-
-          if (np = snprintf(buf,nb,"%c\n", (i < n-1) ? ',' : ')'), np >= nb)  {
-            nb -= np;
-            goto finished;
-          }
-          buf += np;
-          nb -= np;
         }
       }
       break;
 
-    case JVST_CNODE_AND:
-    case JVST_CNODE_OR:
-    case JVST_CNODE_XOR:
-    case JVST_CNODE_NOT:
-
-    case JVST_CNODE_STR_LENRANGE:
-    case JVST_CNODE_STR_MATCH:
-    case JVST_CNODE_STR_EQUAL:
+    case JVST_CNODE_NUM_INTEGER:
+      xsnprintf(buf,"IS_INTEGER");
+      break;
 
     case JVST_CNODE_NUM_RANGE:
-    case JVST_CNODE_NUM_INTEGER:
+      xsnprintf(buf,"NUM_RANGE(");
+      if (node->u.num_range.flags & JVST_CNODE_RANGE_EXCL_MIN) {
+        xsnprintf(buf,"%g < ", node->u.num_range.min);
+      } else if (node->u.num_range.flags & JVST_CNODE_RANGE_MIN) {
+        xsnprintf(buf,"%g <= ", node->u.num_range.min);
+      }
 
-    case JVST_CNODE_OBJ_NUMPROP_RANGE:
-    case JVST_CNODE_OBJ_PROPS:
+      xsnprintf(buf,"x");
+
+      if (node->u.num_range.flags & JVST_CNODE_RANGE_EXCL_MAX) {
+        xsnprintf(buf,"< %g", node->u.num_range.min);
+      } else if (node->u.num_range.flags & JVST_CNODE_RANGE_MAX) {
+        xsnprintf(buf,"<= %g", node->u.num_range.min);
+      }
+
+      xsnprintf(buf,")");
+      break;
+
+    case JVST_CNODE_AND:
+      op = "AND";
+      goto and_or_xor;
+
+    case JVST_CNODE_OR:
+      op = "OR";
+      goto and_or_xor;
+      /* fallthrough */
+
+    case JVST_CNODE_XOR:
+      op = "XOR";
+      goto and_or_xor;
+
+and_or_xor:
+      {
+        struct jvst_cnode *cond;
+
+        xsnprintf(buf, "%s(\n", op);
+        for(cond = node->u.ctrl; cond != NULL; cond = cond->next) {
+          add_indent(buf,indent+2);
+          jvst_cnode_dump_inner(cond, buf, indent+2);
+          if (cond->next) {
+            xsnprintf(buf,",\n");
+          } else {
+            xsnprintf(buf,"\n");
+            add_indent(buf,indent);
+            xsnprintf(buf,")");
+          }
+        }
+      }
+      break;
+
     case JVST_CNODE_OBJ_PROP_MATCH:
-    case JVST_CNODE_OBJ_REQUIRE:
+      {
+        char match[256] = { 0 };
+        if (node->u.prop_match.match.str.len >= sizeof match) {
+          memcpy(match, node->u.prop_match.match.str.s, sizeof match - 4);
+          match[sizeof match - 4] = '.';
+          match[sizeof match - 3] = '.';
+          match[sizeof match - 2] = '.';
+        } else {
+          memcpy(match, node->u.prop_match.match.str.s, node->u.prop_match.match.str.len);
+        }
 
-    case JVST_CNODE_ARR_NUMITEM_RANGE:
+        xsnprintf(buf,"PROP_MATCH(\n");
+        add_indent(buf, indent+2);
+        {
+          char *prefix = "";
+          char delim = '/';
+          switch (node->u.prop_match.match.dialect) {
+            case RE_LIKE:
+              prefix="L";
+              break;
+            case RE_LITERAL:
+              delim = '"';
+              break;
+
+            case RE_GLOB:
+              prefix="G";
+              break;
+            case RE_NATIVE:
+              break;
+            default:
+              prefix="???";
+              break;
+          }
+          xsnprintf(buf,"%s%c%s%c,\n", prefix,delim,match,delim);
+          add_indent(buf, indent+2);
+          jvst_cnode_dump_inner(node->u.prop_match.constraint, buf, indent+2);
+          xsnprintf(buf,"\n");
+          add_indent(buf,indent);
+          xsnprintf(buf,")");
+        }
+      }
+      break;
+
+    case JVST_CNODE_COUNT_RANGE:
+      xsnprintf(buf,"COUNT_RANGE(");
+      if (node->u.counts.min > 0) {
+        xsnprintf(buf,"%zu <= ", node->u.counts.min);
+      }
+
+      xsnprintf(buf,"x");
+
+      if (node->u.counts.max > 0) {
+        xsnprintf(buf,"<= %zu", node->u.counts.min);
+      }
+
+      xsnprintf(buf,")");
+      break;
+
+    case JVST_CNODE_OBJ_REQUIRED:
+      {
+        struct ast_string_set *ss;
+
+        xsnprintf(buf,"REQUIRED(\n");
+        for (ss = node->u.required; ss != NULL; ss = ss->next) {
+          char str[256] = { 0 };
+          size_t n;
+
+          n = ss->str.len;
+          if (n < sizeof str) {
+            memcpy(str, ss->str.s, n);
+          } else {
+            memcpy(str, ss->str.s, sizeof str - 4);
+            memcpy(str + sizeof str - 4, "...", 4);
+          }
+
+          add_indent(buf, indent+2);
+          xsnprintf(buf,"\"%s\"%s\n", str, (ss->next != NULL) ? "," : "");
+        }
+        add_indent(buf, indent);
+        xsnprintf(buf,")");
+      }
+      break;
+
+    case JVST_CNODE_NOT:
+    case JVST_CNODE_STR_MATCH:
     case JVST_CNODE_ARR_ITEM:
     case JVST_CNODE_ARR_ADDITIONAL:
     case JVST_CNODE_ARR_UNIQUE:
       fprintf(stderr, "**not implemented**\n");
       abort();
   }
-
-finished:
-  return nb0 - nb;
 }
 
 int jvst_cnode_dump(struct jvst_cnode *node, char *buf, size_t nb)
 {
-  if (jvst_cnode_dump_inner(node, buf, nb, 0) < nb) {
-    return 0;
-  }
+  struct sbuf b = {
+    .buf = buf,
+    .cap = nb,
+    .len = 0,
+    .np = 0,
+  };
 
-  return -1;
+  jvst_cnode_dump_inner(node, &b, 0);
+  return (b.len < b.cap) ? 0 : -1;
 }
 
 // Translates the AST into a contraint tree and optimizes the constraint
@@ -332,12 +434,157 @@ struct jvst_cnode *jvst_cnode_from_ast(struct ast_schema *ast);
 struct jvst_cnode *jvst_cnode_translate_ast(struct ast_schema *ast)
 {
   struct jvst_cnode *node;
+  enum json_valuetype types;
+
+  assert(ast != NULL);
+  types = ast->types;
 
   // TODO - implement ast->some_of.set != NULL logic
   // top is a switch
-  node = cnode_new_switch(true);
+  if (types == 0) {
+    node = cnode_new_switch(true);
+  } else {
+    struct jvst_cnode *valid;
 
-  (void)ast;
+    node = cnode_new_switch(false);
+    valid = jvst_cnode_alloc(JVST_CNODE_VALID);
+
+    if (types & JSON_VALUE_OBJECT) {
+      node->u.sw[SJP_OBJECT_BEG] = valid;
+    }
+
+    if (types & JSON_VALUE_ARRAY) {
+      node->u.sw[SJP_ARRAY_BEG] = valid;
+    }
+
+    if (types & JSON_VALUE_STRING) {
+      node->u.sw[SJP_STRING] = valid;
+    }
+
+    if (types & JSON_VALUE_STRING) {
+      node->u.sw[SJP_STRING] = valid;
+    }
+
+    if (types & JSON_VALUE_NUMBER) {
+      node->u.sw[SJP_NUMBER] = valid;
+    }
+
+    if (types & JSON_VALUE_INTEGER) {
+      node->u.sw[SJP_NUMBER] = jvst_cnode_alloc(JVST_CNODE_NUM_INTEGER);
+    }
+
+    if (types & JSON_VALUE_BOOL) {
+      node->u.sw[SJP_TRUE] = valid;
+      node->u.sw[SJP_FALSE] = valid;
+    }
+
+    if (types & JSON_VALUE_NULL) {
+      node->u.sw[SJP_NULL] = valid;
+    }
+  }
+
+  if (ast->kws & (KWS_MINIMUM|KWS_MAXIMUM)) {
+    enum JVST_CNODE_RANGEFLAGS flags = 0;
+    double min = 0, max = 0;
+    struct jvst_cnode *range, *jxn;
+
+    if (ast->kws & KWS_MINIMUM) {
+      flags |= (ast->exclusive_minimum ? JVST_CNODE_RANGE_EXCL_MIN : JVST_CNODE_RANGE_MIN);
+      min = ast->minimum;
+    }
+
+    if (ast->kws & KWS_MAXIMUM) {
+      flags |= (ast->exclusive_maximum ? JVST_CNODE_RANGE_EXCL_MAX : JVST_CNODE_RANGE_MAX);
+      max = ast->maximum;
+    }
+
+    range = jvst_cnode_alloc(JVST_CNODE_NUM_RANGE);
+    range->u.num_range.flags = flags;
+    range->u.num_range.min = min;
+    range->u.num_range.max = max;
+
+    jxn = jvst_cnode_alloc(JVST_CNODE_AND);
+    jxn->u.ctrl = range;
+    range->next = node->u.sw[SJP_NUMBER];
+    node->u.sw[SJP_NUMBER] = jxn;
+  }
+
+  if (ast->properties.set != NULL) {
+    struct jvst_cnode **plist, *phead, *prop_jxn, *top_jxn;
+    struct ast_property_schema *pset;
+
+    top_jxn = prop_jxn = phead = NULL;
+    plist = &phead;
+
+    for(pset = ast->properties.set; pset != NULL; pset = pset->next) {
+      struct jvst_cnode *pnode;
+      pnode = jvst_cnode_alloc(JVST_CNODE_OBJ_PROP_MATCH);
+      pnode->u.prop_match.match = pset->pattern;
+      pnode->u.prop_match.constraint = jvst_cnode_translate_ast(pset->schema);
+      *plist = pnode;
+      plist = &pnode->next;
+    }
+
+    prop_jxn = jvst_cnode_alloc(JVST_CNODE_OR);
+    prop_jxn->u.ctrl = phead;
+    assert(phead != NULL);
+
+    top_jxn = jvst_cnode_alloc(JVST_CNODE_AND);
+    top_jxn->u.ctrl = prop_jxn;
+    prop_jxn->next = node->u.sw[SJP_OBJECT_BEG];
+
+    node->u.sw[SJP_OBJECT_BEG] = top_jxn;
+  }
+
+  if (ast->kws & KWS_MINMAX_PROPERTIES) {
+    struct jvst_cnode *range, *jxn;
+
+    range = jvst_cnode_alloc(JVST_CNODE_COUNT_RANGE);
+    range->u.counts.min = ast->min_properties;
+    range->u.counts.max = ast->max_properties;
+
+    jxn = jvst_cnode_alloc(JVST_CNODE_AND);
+    jxn->u.ctrl = range;
+    range->next = node->u.sw[SJP_OBJECT_BEG];
+    node->u.sw[SJP_OBJECT_BEG] = jxn;
+  }
+
+  if (ast->required.set != NULL) {
+    struct jvst_cnode *req, *jxn;
+
+    req = jvst_cnode_alloc(JVST_CNODE_OBJ_REQUIRED);
+    req->u.required = ast->required.set;
+
+    jxn = jvst_cnode_alloc(JVST_CNODE_AND);
+    jxn->u.ctrl = req;
+    req->next = node->u.sw[SJP_OBJECT_BEG];
+    node->u.sw[SJP_OBJECT_BEG] = jxn;
+  }
+
+  if (ast->some_of.set != NULL) {
+    struct jvst_cnode *top_jxn, *some_jxn, **conds;
+    struct ast_schema_set *sset;
+    enum JVST_CNODE_TYPE op = JVST_CNODE_OR;
+
+    if (ast->some_of.min == ast->some_of.max) {
+      op = (ast->some_of.min == 1) ? JVST_CNODE_XOR : JVST_CNODE_AND;
+    }
+
+    some_jxn = jvst_cnode_alloc(op);
+    conds = &some_jxn->u.ctrl;
+    some_jxn->u.ctrl = NULL;
+    for (sset = ast->some_of.set; sset != NULL; sset = sset->next) {
+      struct jvst_cnode *c;
+      c = jvst_cnode_translate_ast(sset->schema);
+      *conds = c;
+      conds = &c->next;
+    }
+
+    top_jxn = jvst_cnode_alloc(JVST_CNODE_AND);
+    top_jxn->u.ctrl = some_jxn;
+    some_jxn->next = node;
+    node = top_jxn;
+  }
 
   return node;
 }

--- a/src/validate_constraints.c
+++ b/src/validate_constraints.c
@@ -1,0 +1,344 @@
+#include "validate_constraints.h"
+
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "xalloc.h"
+
+#include "jvst_macros.h"
+#include "sjp_testing.h"
+
+#define SHOULD_NOT_REACH() abort()
+
+enum { JVST_CNODE_CHUNKSIZE = 1024 };
+
+struct jvst_cnode_pool {
+  struct jvst_cnode_pool *next;
+  struct jvst_cnode items[JVST_CNODE_CHUNKSIZE];
+};
+
+/* XXX - should these be global vars?  also, not thread safe. */
+static struct jvst_cnode_pool *pool = NULL;
+static size_t pool_item = 0;
+static struct jvst_cnode *freelist = NULL;
+
+void json_string_finalize(struct json_string *s)
+{
+  // XXX - implement
+  (void)s;
+}
+
+static struct jvst_cnode *cnode_new(void)
+{
+  struct jvst_cnode_pool *p;
+
+  if (pool == NULL) {
+    goto new_pool;
+  }
+
+  // first try bump allocation
+  if (pool_item < ARRAYLEN(pool->items)) {
+    return &pool->items[pool_item++];
+  }
+
+  // next try the free list
+  if (freelist != NULL) {
+    struct jvst_cnode *n = freelist;
+    freelist = freelist->next;
+    return n;
+  }
+
+new_pool:
+  // fall back to allocating a new pool
+  p = xmalloc(sizeof *p);
+  p->next = pool;
+  pool = p;
+  pool_item = 1;
+  return &p->items[0];
+}
+
+struct jvst_cnode *jvst_cnode_alloc(enum JVST_CNODE_TYPE type)
+{
+  struct jvst_cnode *n;
+  n = cnode_new();
+  n->type = type;
+  return n;
+}
+
+static struct jvst_cnode *cnode_new_switch(int allvalid)
+{
+  size_t i,n;
+  struct jvst_cnode *node, *v, *inv;
+
+  node = jvst_cnode_alloc(JVST_CNODE_SWITCH);
+  v = inv = jvst_cnode_alloc(JVST_CNODE_INVALID);
+  if (allvalid) {
+    v = jvst_cnode_alloc(JVST_CNODE_VALID);
+  }
+
+  for(i=0, n=ARRAYLEN(node->u.sw); i < n; i++) {
+    node->u.sw[i] = v;
+  }
+
+  // ARRAY_END and OBJECT_END are always invalid
+  if (allvalid) {
+    node->u.sw[SJP_ARRAY_END] = inv;
+    node->u.sw[SJP_OBJECT_END] = inv;
+  }
+
+  return node;
+}
+
+void jvst_cnode_free(struct jvst_cnode *n)
+{
+  // simple logic: add back to freelist
+  memset(n, 0, sizeof *n);
+  n->next = freelist;
+  freelist = n;
+}
+
+void jvst_cnode_free_tree(struct jvst_cnode *root)
+{
+  struct jvst_cnode *node, *next;
+  size_t i,n;
+
+  for(node = root; node != NULL; node = next) {
+    next = node->next;
+
+    switch (node->type) {
+      case JVST_CNODE_INVALID:
+      case JVST_CNODE_VALID:
+        break;
+
+      case JVST_CNODE_AND:
+      case JVST_CNODE_OR:
+      case JVST_CNODE_XOR:
+      case JVST_CNODE_NOT:
+        jvst_cnode_free_tree(node->u.ctrl);
+        break;
+
+      case JVST_CNODE_SWITCH:
+        for (i=0,n=ARRAYLEN(node->u.sw); i < n; i++) {
+          if (node->u.sw[i] != NULL) {
+            jvst_cnode_free_tree(node->u.sw[i]);
+          }
+        }
+        break;
+
+      /* constrains with no child nodes */
+      case JVST_CNODE_NUM_INTEGER:
+      case JVST_CNODE_NUM_RANGE:
+      case JVST_CNODE_ARR_UNIQUE:
+      case JVST_CNODE_STR_LENRANGE:
+      case JVST_CNODE_OBJ_NUMPROP_RANGE:
+      case JVST_CNODE_ARR_NUMITEM_RANGE:
+        break;
+
+      case JVST_CNODE_STR_MATCH:
+        json_string_finalize(&node->u.str_match.pattern);
+        if (node->u.str_match.matcher) {
+          // XXX - ensure that fsm is torn down
+          // do we pool FSMs?  check if they're ref counted.
+        }
+        break;
+
+      case JVST_CNODE_STR_EQUAL:
+        json_string_finalize(&node->u.str_equal);
+        break;
+
+      case JVST_CNODE_OBJ_PROPS:
+        for (i=0, n=node->u.props.n; i < n; i++) {
+          struct jvst_cnode *child;
+
+          json_string_finalize(&node->u.props.names[i]);
+          child = &node->u.props.constraints[i];
+          if (child != NULL) {
+            jvst_cnode_free_tree(child);
+          }
+        }
+        break;
+
+      case JVST_CNODE_OBJ_PROP_MATCH:
+        json_string_finalize(&node->u.prop_match.pattern);
+        if (node->u.prop_match.matcher != NULL) {
+          // XXX - ensure that fsm is torn down
+          // do we pool FSMs?  check if they're ref counted.
+        }
+
+        if (node->u.prop_match.constraint != NULL) {
+          jvst_cnode_free_tree(node->u.prop_match.constraint);
+        }
+        break;
+
+      case JVST_CNODE_OBJ_REQUIRE:
+        for (i=0, n=node->u.required.n; i < n; i++) {
+          json_string_finalize(&node->u.required.s[i]);
+        }
+        break;
+
+      case JVST_CNODE_ARR_ITEM:
+      case JVST_CNODE_ARR_ADDITIONAL:
+        if (node->u.arr_item != NULL) {
+          jvst_cnode_free_tree(node->u.arr_item);
+        }
+        break;
+
+      default:
+        SHOULD_NOT_REACH();
+    }
+
+    // now free the node
+    jvst_cnode_free(node);
+  }
+}
+
+static inline size_t xsnprintf(char *p, size_t sz, const char *fmt, ...)
+{
+  int ret;
+  va_list args;
+
+  va_start(args, fmt);
+  if (ret = vsnprintf(p,sz,fmt,args), ret < 0) {
+    // FIXME: handle this more gracefully!
+    perror("ERROR dumping cnode to a buffer");
+    abort();
+  }
+  va_end(args);
+
+  return (size_t)ret;
+}
+
+static int add_indent(char *buf, size_t nb, int indent)
+{
+  int i;
+  
+  for (i=0; i < indent && nb > 0; i++, nb--) {
+    buf[i] = ' ';
+  }
+
+  return indent;
+}
+
+// returns number of bytes written
+static size_t jvst_cnode_dump_inner(struct jvst_cnode *node, char *buf, size_t nb0, int indent)
+{
+  size_t nb,np;
+
+  nb = nb0;
+
+  if (node == NULL) {
+    np = xsnprintf(buf, nb, "<null>");
+    nb -= np;
+    goto finished;
+  }
+
+  switch (node->type) {
+    case JVST_CNODE_INVALID:
+    case JVST_CNODE_VALID:
+      np = xsnprintf(buf, nb, (node->type == JVST_CNODE_VALID) ? "VALID" : "INVALID");
+      nb -= np;
+      goto finished;
+
+    case JVST_CNODE_SWITCH:
+      {
+        size_t i,n;
+
+        if (np = xsnprintf(buf,nb, "SWITCH(\n"), np >= nb) {
+          nb -= np;
+          goto finished;
+        }
+
+        buf += np;
+        nb -= np;
+
+        n = ARRAYLEN(node->u.sw);
+        for (i=0; i < n; i++) {
+          if (np = add_indent(buf,nb,indent+2), np >= nb) {
+            nb -= np;
+            goto finished;
+          }
+          buf += np;
+          nb -= np;
+
+          if (np = snprintf(buf,nb,"%-10s:", evt2name(i)), np >= nb) {
+            nb -= np;
+            goto finished;
+          }
+          buf += np;
+          nb -= np;
+
+          if (np = jvst_cnode_dump_inner(node->u.sw[i], buf, nb, indent+2), np > nb) {
+            nb -= np;
+            goto finished;
+          }
+          buf += np;
+          nb -= np;
+
+          if (np = snprintf(buf,nb,"%c\n", (i < n-1) ? ',' : ')'), np >= nb)  {
+            nb -= np;
+            goto finished;
+          }
+          buf += np;
+          nb -= np;
+        }
+      }
+      break;
+
+    case JVST_CNODE_AND:
+    case JVST_CNODE_OR:
+    case JVST_CNODE_XOR:
+    case JVST_CNODE_NOT:
+
+    case JVST_CNODE_STR_LENRANGE:
+    case JVST_CNODE_STR_MATCH:
+    case JVST_CNODE_STR_EQUAL:
+
+    case JVST_CNODE_NUM_RANGE:
+    case JVST_CNODE_NUM_INTEGER:
+
+    case JVST_CNODE_OBJ_NUMPROP_RANGE:
+    case JVST_CNODE_OBJ_PROPS:
+    case JVST_CNODE_OBJ_PROP_MATCH:
+    case JVST_CNODE_OBJ_REQUIRE:
+
+    case JVST_CNODE_ARR_NUMITEM_RANGE:
+    case JVST_CNODE_ARR_ITEM:
+    case JVST_CNODE_ARR_ADDITIONAL:
+    case JVST_CNODE_ARR_UNIQUE:
+      fprintf(stderr, "**not implemented**\n");
+      abort();
+  }
+
+finished:
+  return nb0 - nb;
+}
+
+int jvst_cnode_dump(struct jvst_cnode *node, char *buf, size_t nb)
+{
+  if (jvst_cnode_dump_inner(node, buf, nb, 0) < nb) {
+    return 0;
+  }
+
+  return -1;
+}
+
+// Translates the AST into a contraint tree and optimizes the constraint
+// tree
+struct jvst_cnode *jvst_cnode_from_ast(struct ast_schema *ast);
+
+// Just do a raw translation without doing any optimization of the
+// constraint tree
+struct jvst_cnode *jvst_cnode_translate_ast(struct ast_schema *ast)
+{
+  struct jvst_cnode *node;
+
+  // TODO - implement ast->some_of.set != NULL logic
+  // top is a switch
+  node = cnode_new_switch(true);
+
+  (void)ast;
+
+  return node;
+}
+

--- a/src/validate_constraints.h
+++ b/src/validate_constraints.h
@@ -27,110 +27,118 @@
  */
 
 enum jvst_cnode_rangeflags {
-  JVST_CNODE_RANGE_MIN      = (1<<0),
-  JVST_CNODE_RANGE_MAX      = (1<<1),
-  JVST_CNODE_RANGE_EXCL_MIN = (1<<2),
-  JVST_CNODE_RANGE_EXCL_MAX = (1<<3),
+	JVST_CNODE_RANGE_MIN      = (1 << 0),
+	JVST_CNODE_RANGE_MAX      = (1 << 1),
+	JVST_CNODE_RANGE_EXCL_MIN = (1 << 2),
+	JVST_CNODE_RANGE_EXCL_MAX = (1 << 3),
 };
 
 enum jvst_cnode_type {
-  /* Control nodes */
-  JVST_CNODE_INVALID = 0, // node always returns invalid
-  JVST_CNODE_VALID,       // node always returns valid
+	/* Control nodes */
+	JVST_CNODE_INVALID = 0, // node always returns invalid
+	JVST_CNODE_VALID,       // node always returns valid
 
-  JVST_CNODE_AND, // requires all nodes to be valid
-  JVST_CNODE_OR,  // requires at least one node to be valid
-  JVST_CNODE_XOR, // requires exactly one node to be valid
-  JVST_CNODE_NOT,
+	JVST_CNODE_AND, // requires all nodes to be valid
+	JVST_CNODE_OR,  // requires at least one node to be valid
+	JVST_CNODE_XOR, // requires exactly one node to be valid
+	JVST_CNODE_NOT,
 
-  /* Token-switch node */
-  JVST_CNODE_SWITCH,
+	/* Token-switch node */
+	JVST_CNODE_SWITCH,
 
-  /* range for string lengths, number of object properties, number of
-   * array items */
-  JVST_CNODE_COUNT_RANGE,
+	/* range for string lengths, number of object properties, number of
+	 * array items */
+	JVST_CNODE_COUNT_RANGE,
 
-  /* Constraint nodes */
-  JVST_CNODE_STR_MATCH,
+	/* Constraint nodes */
+	JVST_CNODE_STR_MATCH,
 
-  JVST_CNODE_NUM_RANGE,
-  JVST_CNODE_NUM_INTEGER,
+	JVST_CNODE_NUM_RANGE,
+	JVST_CNODE_NUM_INTEGER,
 
-  JVST_CNODE_OBJ_PROP_SET,
-  JVST_CNODE_OBJ_PROP_MATCH,
-  JVST_CNODE_OBJ_REQUIRED,
+	JVST_CNODE_OBJ_PROP_SET,
+	JVST_CNODE_OBJ_PROP_MATCH,
+	JVST_CNODE_OBJ_REQUIRED,
 
-  JVST_CNODE_ARR_ITEM,
-  JVST_CNODE_ARR_ADDITIONAL,
-  JVST_CNODE_ARR_UNIQUE,
+	JVST_CNODE_ARR_ITEM,
+	JVST_CNODE_ARR_ADDITIONAL,
+	JVST_CNODE_ARR_UNIQUE,
 };
 
 struct jvst_cnode {
-  enum jvst_cnode_type type;
+	enum jvst_cnode_type type;
 
-  struct jvst_cnode *next;
+	struct jvst_cnode *next;
 
-  union {
-    /* type switch node */
-    struct jvst_cnode *sw[SJP_EVENT_MAX];
+	union {
+		/* type switch node */
+		struct jvst_cnode *sw[SJP_EVENT_MAX];
 
-    /* control nodes */
-    struct jvst_cnode *ctrl;
+		/* control nodes */
+		struct jvst_cnode *ctrl;
 
-    /* constraint for string length, array length,
-     * number of object properties
-     */
-    struct {
-      size_t min;
-      size_t max; // 0 indicates no upper bound
-    } counts;
+		/* constraint for string length, array length,
+		 * number of object properties
+		 */
+		struct {
+			size_t min;
+			size_t max; // 0 indicates no upper bound
+		} counts;
 
-    /* for string pattern matching or matching string sets */
-    struct ast_regexp str_match;
+		/* for string pattern matching or matching string sets */
+		struct ast_regexp str_match;
 
-    /* for number ranges */
-    struct {
-      enum jvst_cnode_rangeflags flags;
-      double min;
-      double max;
-    } num_range;
+		/* for number ranges */
+		struct {
+			enum jvst_cnode_rangeflags flags;
+			double min;
+			double max;
+		} num_range;
 
-    /* object required property */
-    struct ast_string_set *required;
+		/* object required property */
+		struct ast_string_set *required;
 
-    struct jvst_cnode *prop_set;
+		struct jvst_cnode *prop_set;
 
-    /* object property constraints */
-    struct {
-      struct ast_regexp match;
-      struct jvst_cnode *constraint;
-    } prop_match;
+		/* object property constraints */
+		struct {
+			struct ast_regexp match;
+			struct jvst_cnode *constraint;
+		} prop_match;
 
-    // for array item and additional_item constraints
-    struct jvst_cnode *arr_item;
-  } u;
+		// for array item and additional_item constraints
+		struct jvst_cnode *arr_item;
+	} u;
 };
 
-struct jvst_cnode *jvst_cnode_alloc(enum jvst_cnode_type type);
-void jvst_cnode_free(struct jvst_cnode *n);
-void jvst_cnode_free_tree(struct jvst_cnode *n);
+struct jvst_cnode *
+jvst_cnode_alloc(enum jvst_cnode_type type);
+void
+jvst_cnode_free(struct jvst_cnode *n);
+void
+jvst_cnode_free_tree(struct jvst_cnode *n);
 
 // Translates the AST into a contraint tree and optimizes the constraint
 // tree
-struct jvst_cnode *jvst_cnode_from_ast(struct ast_schema *ast);
+struct jvst_cnode *
+jvst_cnode_from_ast(struct ast_schema *ast);
 
 // Just do a raw translation without doing any optimization of the
 // constraint tree
-struct jvst_cnode *jvst_cnode_translate_ast(struct ast_schema *ast);
+struct jvst_cnode *
+jvst_cnode_translate_ast(struct ast_schema *ast);
 
 // Optimize the cnode tree.  Returns a new tree.
-struct jvst_cnode *jvst_cnode_optimize(struct jvst_cnode *tree);
+struct jvst_cnode *
+jvst_cnode_optimize(struct jvst_cnode *tree);
 
 // Writes a textual represetnation of the cnode into the buffer,
 // returns 0 if the representation fit, non-zero otherwise
-int jvst_cnode_dump(struct jvst_cnode *node, char *buf, size_t nb);
+int
+jvst_cnode_dump(struct jvst_cnode *node, char *buf, size_t nb);
 
 #undef MODULE_NAME
 
 #endif /* VALIDATE_CONSTRAINTS_H */
 
+/* vim: set tabstop=8 shiftwidth=8 noexpandtab */

--- a/src/validate_constraints.h
+++ b/src/validate_constraints.h
@@ -137,6 +137,10 @@ jvst_cnode_optimize(struct jvst_cnode *tree);
 int
 jvst_cnode_dump(struct jvst_cnode *node, char *buf, size_t nb);
 
+// for debugging, prints node to stderr
+void
+jvst_cnode_print(struct jvst_cnode *node);
+
 #undef MODULE_NAME
 
 #endif /* VALIDATE_CONSTRAINTS_H */

--- a/src/validate_constraints.h
+++ b/src/validate_constraints.h
@@ -26,14 +26,14 @@
  *
  */
 
-enum JVST_CNODE_RANGEFLAGS {
+enum jvst_cnode_rangeflags {
   JVST_CNODE_RANGE_MIN      = (1<<0),
   JVST_CNODE_RANGE_MAX      = (1<<1),
   JVST_CNODE_RANGE_EXCL_MIN = (1<<2),
   JVST_CNODE_RANGE_EXCL_MAX = (1<<3),
 };
 
-enum JVST_CNODE_TYPE {
+enum jvst_cnode_type {
   /* Control nodes */
   JVST_CNODE_INVALID = 0, // node always returns invalid
   JVST_CNODE_VALID,       // node always returns valid
@@ -66,7 +66,7 @@ enum JVST_CNODE_TYPE {
 };
 
 struct jvst_cnode {
-  enum JVST_CNODE_TYPE type;
+  enum jvst_cnode_type type;
 
   struct jvst_cnode *next;
 
@@ -90,7 +90,7 @@ struct jvst_cnode {
 
     /* for number ranges */
     struct {
-      enum JVST_CNODE_RANGEFLAGS flags;
+      enum jvst_cnode_rangeflags flags;
       double min;
       double max;
     } num_range;
@@ -111,7 +111,7 @@ struct jvst_cnode {
   } u;
 };
 
-struct jvst_cnode *jvst_cnode_alloc(enum JVST_CNODE_TYPE type);
+struct jvst_cnode *jvst_cnode_alloc(enum jvst_cnode_type type);
 void jvst_cnode_free(struct jvst_cnode *n);
 void jvst_cnode_free_tree(struct jvst_cnode *n);
 

--- a/src/validate_constraints.h
+++ b/src/validate_constraints.h
@@ -141,4 +141,5 @@ jvst_cnode_dump(struct jvst_cnode *node, char *buf, size_t nb);
 
 #endif /* VALIDATE_CONSTRAINTS_H */
 
-/* vim: set tabstop=8 shiftwidth=8 noexpandtab */
+/* vim: set tabstop=8 shiftwidth=8 noexpandtab: */
+

--- a/src/validate_constraints.h
+++ b/src/validate_constraints.h
@@ -113,10 +113,15 @@ struct jvst_cnode {
 
 struct jvst_cnode *
 jvst_cnode_alloc(enum jvst_cnode_type type);
+
 void
 jvst_cnode_free(struct jvst_cnode *n);
+
 void
 jvst_cnode_free_tree(struct jvst_cnode *n);
+
+const char *
+jvst_cnode_type_name(enum jvst_cnode_type type);
 
 // Translates the AST into a contraint tree and optimizes the constraint
 // tree

--- a/src/validate_constraints.h
+++ b/src/validate_constraints.h
@@ -56,6 +56,7 @@ enum JVST_CNODE_TYPE {
   JVST_CNODE_NUM_RANGE,
   JVST_CNODE_NUM_INTEGER,
 
+  JVST_CNODE_OBJ_PROP_SET,
   JVST_CNODE_OBJ_PROP_MATCH,
   JVST_CNODE_OBJ_REQUIRED,
 
@@ -66,6 +67,7 @@ enum JVST_CNODE_TYPE {
 
 struct jvst_cnode {
   enum JVST_CNODE_TYPE type;
+
   struct jvst_cnode *next;
 
   union {
@@ -96,6 +98,8 @@ struct jvst_cnode {
     /* object required property */
     struct ast_string_set *required;
 
+    struct jvst_cnode *prop_set;
+
     /* object property constraints */
     struct {
       struct ast_regexp match;
@@ -118,6 +122,9 @@ struct jvst_cnode *jvst_cnode_from_ast(struct ast_schema *ast);
 // Just do a raw translation without doing any optimization of the
 // constraint tree
 struct jvst_cnode *jvst_cnode_translate_ast(struct ast_schema *ast);
+
+// Optimize the cnode tree.  Returns a new tree.
+struct jvst_cnode *jvst_cnode_optimize(struct jvst_cnode *tree);
 
 // Writes a textual represetnation of the cnode into the buffer,
 // returns 0 if the representation fit, non-zero otherwise

--- a/src/validate_constraints.h
+++ b/src/validate_constraints.h
@@ -46,20 +46,19 @@ enum JVST_CNODE_TYPE {
   /* Token-switch node */
   JVST_CNODE_SWITCH,
 
+  /* range for string lengths, number of object properties, number of
+   * array items */
+  JVST_CNODE_COUNT_RANGE,
+
   /* Constraint nodes */
-  JVST_CNODE_STR_LENRANGE,
   JVST_CNODE_STR_MATCH,
-  JVST_CNODE_STR_EQUAL,
 
   JVST_CNODE_NUM_RANGE,
   JVST_CNODE_NUM_INTEGER,
 
-  JVST_CNODE_OBJ_NUMPROP_RANGE,
-  JVST_CNODE_OBJ_PROPS,
   JVST_CNODE_OBJ_PROP_MATCH,
-  JVST_CNODE_OBJ_REQUIRE,
+  JVST_CNODE_OBJ_REQUIRED,
 
-  JVST_CNODE_ARR_NUMITEM_RANGE,
   JVST_CNODE_ARR_ITEM,
   JVST_CNODE_ARR_ADDITIONAL,
   JVST_CNODE_ARR_UNIQUE,
@@ -80,43 +79,26 @@ struct jvst_cnode {
      * number of object properties
      */
     struct {
-      enum JVST_CNODE_RANGEFLAGS flags;
       size_t min;
-      size_t max;
+      size_t max; // 0 indicates no upper bound
     } counts;
 
     /* for string pattern matching or matching string sets */
-    struct {
-      struct json_string pattern;
-      struct fsm *matcher;
-    } str_match;
-
-    /* special case if it's just a comparison */
-    struct json_string str_equal;
+    struct ast_regexp str_match;
 
     /* for number ranges */
     struct {
       enum JVST_CNODE_RANGEFLAGS flags;
       double min;
       double max;
-    } num_constraints;
+    } num_range;
 
     /* object required property */
-    struct {
-      size_t n;
-      struct json_string *s;
-    } required;
+    struct ast_string_set *required;
 
     /* object property constraints */
     struct {
-      size_t n;
-      struct json_string *names;
-      struct jvst_cnode *constraints;
-    } props;
-
-    struct {
-      struct json_string pattern;
-      struct fsm *matcher;
+      struct ast_regexp match;
       struct jvst_cnode *constraint;
     } prop_match;
 

--- a/src/validate_sbuf.c
+++ b/src/validate_sbuf.c
@@ -1,0 +1,54 @@
+#include "validate_sbuf.h"
+
+#include <assert.h>
+#include <stdarg.h>
+#include <stdio.h>
+
+int
+sbuf_indent(struct sbuf *buf, int indent)
+{
+	int i;
+
+	for (i = 0; i < indent; i++) {
+		if (buf->len >= buf->cap) {
+			break;
+		}
+		buf->buf[buf->len++] = ' ';
+	}
+
+	buf->np += indent;
+
+	return indent;
+}
+
+void
+sbuf_snprintf(struct sbuf *b, const char *fmt, ...)
+{
+	int ret;
+	va_list args;
+	char *p;
+	size_t nb;
+
+	assert(b->len <= b->cap);
+
+	p  = b->buf + b->len;
+	nb = b->cap - b->len;
+
+	va_start(args, fmt);
+	ret = vsnprintf(p, nb, fmt, args);
+	va_end(args);
+	if (ret < 0) {
+		// FIXME: handle this more gracefully!
+		perror("ERROR dumping cnode to a buffer");
+		abort();
+	}
+
+	if ((size_t)ret <= nb) {
+		b->len += ret;
+	} else {
+		b->len = b->cap;
+	}
+
+	b->np += ret;
+}
+

--- a/src/validate_sbuf.h
+++ b/src/validate_sbuf.h
@@ -1,0 +1,20 @@
+#ifndef VALIDATE_SBUF_H
+#define VALIDATE_SBUF_H
+
+#include <stdlib.h>
+
+struct sbuf {
+	char *buf;
+	size_t cap;
+	size_t len;
+	size_t np;
+};
+
+int
+sbuf_indent(struct sbuf *buf, int indent);
+
+void
+sbuf_snprintf(struct sbuf *b, const char *fmt, ...);
+
+#endif /* VALIDATE_SBUF_H */
+

--- a/src/validate_testing.c
+++ b/src/validate_testing.c
@@ -23,452 +23,471 @@ static struct ast_schema_set ar_schemasets[NUM_TEST_THINGS];
 static struct jvst_cnode ar_cnodes[NUM_TEST_THINGS];
 
 // Returns a constant empty schema
-struct ast_schema *empty_schema(void)
+struct ast_schema *
+empty_schema(void)
 {
-  static struct ast_schema empty = { 0 };
-  return &empty;
+	static struct ast_schema empty = {0};
+	return &empty;
 }
 
-struct json_string newstr(const char *s)
+struct json_string
+newstr(const char *s)
 {
-  struct json_string str = { .s = s, .len = strlen(s) };
-  return str;
+	struct json_string str = {.s = s, .len = strlen(s)};
+	return str;
 }
 
-static struct ast_string_set *stringset_alloc(struct arena_info *A)
+static struct ast_string_set *
+stringset_alloc(struct arena_info *A)
 {
-  struct ast_string_set *elt;
-  size_t i,max;
+	struct ast_string_set *elt;
+	size_t i, max;
 
-  max = ARRAYLEN(ar_stringsets);
-  i = A->nstr++;
-  if (A->nstr >= max) {
-    fprintf(stderr, "too many string sets: %zu max\n", max);
-    abort();
-  }
+	max = ARRAYLEN(ar_stringsets);
+	i   = A->nstr++;
+	if (A->nstr >= max) {
+		fprintf(stderr, "too many string sets: %zu max\n", max);
+		abort();
+	}
 
-  elt = &ar_stringsets[i];
-  memset(elt, 0, sizeof *elt);
+	elt = &ar_stringsets[i];
+	memset(elt, 0, sizeof *elt);
 
-  return elt;
+	return elt;
 }
 
-struct ast_string_set *stringset(struct arena_info *A, ...)
+struct ast_string_set *
+stringset(struct arena_info *A, ...)
 {
-  struct ast_string_set *ss = NULL, **ssp = &ss;
-  va_list args;
+	struct ast_string_set *ss = NULL, **ssp = &ss;
+	va_list args;
 
-  va_start(args, A);
-  for(;;) {
-    struct ast_string_set *elt;
-    struct json_string str;
-    const char *s;
-    size_t i;
+	va_start(args, A);
+	for (;;) {
+		struct ast_string_set *elt;
+		struct json_string str;
+		const char *s;
+		size_t i;
 
-    if (s = va_arg(args, const char *), s == NULL) {
-      break;
-    }
+		if (s = va_arg(args, const char *), s == NULL) {
+			break;
+		}
 
-    elt = stringset_alloc(A);
-    elt->str = newstr(s);
-    *ssp = elt;
-    ssp = &elt->next;
-  }
-  va_end(args);
+		elt      = stringset_alloc(A);
+		elt->str = newstr(s);
+		*ssp     = elt;
+		ssp      = &elt->next;
+	}
+	va_end(args);
 
-  return ss;
+	return ss;
 }
 
-struct ast_schema_set *schema_set(struct arena_info *A, ...)
+struct ast_schema_set *
+schema_set(struct arena_info *A, ...)
 {
-  struct ast_schema_set *sset, **sp;
-  struct ast_schema *s;
-  size_t max;
-  va_list args;
+	struct ast_schema_set *sset, **sp;
+	struct ast_schema *s;
+	size_t max;
+	va_list args;
 
-  va_start(args, A);
+	va_start(args, A);
 
-  sset = NULL;
-  sp = &sset;
-  max = sizeof ar_schemasets / sizeof ar_schemasets[0];
-  while (s = va_arg(args, struct ast_schema *), s != NULL) {
-    struct ast_schema_set *elt;
-    size_t i;
+	sset = NULL;
+	sp   = &sset;
+	max  = sizeof ar_schemasets / sizeof ar_schemasets[0];
+	while (s = va_arg(args, struct ast_schema *), s != NULL) {
+		struct ast_schema_set *elt;
+		size_t i;
 
-    i = A->nset++;
-    if (A->nset >= max) {
-      fprintf(stderr, "too many schema sets: %zu max\n", max);
-      abort();
-    }
+		i = A->nset++;
+		if (A->nset >= max) {
+			fprintf(stderr, "too many schema sets: %zu max\n", max);
+			abort();
+		}
 
-    elt = &ar_schemasets[i];
-    memset(elt, 0, sizeof *elt);
-    elt->schema = s;
-    *sp = elt;
-    sp = &elt->next;
-  }
+		elt = &ar_schemasets[i];
+		memset(elt, 0, sizeof *elt);
+		elt->schema = s;
+		*sp	 = elt;
+		sp	  = &elt->next;
+	}
 
-  va_end(args);
+	va_end(args);
 
-  return sset;
+	return sset;
 }
 
-size_t schema_set_count(struct ast_schema_set *s)
+size_t
+schema_set_count(struct ast_schema_set *s)
 {
-  size_t n;
-  for(n=0; s != NULL; s = s->next, n++) {
-    continue;
-  }
+	size_t n;
+	for (n = 0; s != NULL; s = s->next, n++) {
+		continue;
+	}
 
-  return n;
+	return n;
 }
 
-struct ast_property_names *newpropnames(struct arena_info *A, ...)
+struct ast_property_names *
+newpropnames(struct arena_info *A, ...)
 {
-  size_t i,max;
-  struct ast_property_names *pnames, **pp;
-  va_list args;
+	size_t i, max;
+	struct ast_property_names *pnames, **pp;
+	va_list args;
 
-  pnames = NULL;
-  pp = &pnames;
+	pnames = NULL;
+	pp     = &pnames;
 
-  va_start(args, A);
-  for (;;) {
-    const char *n;
-    struct ast_string_set *set;
+	va_start(args, A);
+	for (;;) {
+		const char *n;
+		struct ast_string_set *set;
 
-    n = va_arg(args, const char *);
-    if (n == NULL) {
-      break;
-    }
+		n = va_arg(args, const char *);
+		if (n == NULL) {
+			break;
+		}
 
-    set = va_arg(args, struct ast_string_set *);
-    i = A->npnames++;
-    max = ARRAYLEN(ar_propnames);
-    if (A->nschema >= max) {
-      fprintf(stderr, "too many schema: %zu max\n", max);
-      abort();
-    }
+		set = va_arg(args, struct ast_string_set *);
+		i   = A->npnames++;
+		max = ARRAYLEN(ar_propnames);
+		if (A->nschema >= max) {
+			fprintf(stderr, "too many schema: %zu max\n", max);
+			abort();
+		}
 
-    *pp = &ar_propnames[i];
-    memset(*pp, 0, sizeof **pp);
-    (*pp)->set = set;
-    (*pp)->pattern.dialect = RE_LITERAL;
-    (*pp)->pattern.str = newstr(n);
-    (*pp)->pattern.fsm = NULL;
+		*pp = &ar_propnames[i];
+		memset(*pp, 0, sizeof **pp);
+		(*pp)->set	     = set;
+		(*pp)->pattern.dialect = RE_LITERAL;
+		(*pp)->pattern.str     = newstr(n);
+		(*pp)->pattern.fsm     = NULL;
 
-    pp = &(*pp)->next;
-  }
-  va_end(args);
+		pp = &(*pp)->next;
+	}
+	va_end(args);
 
-  return pnames;
+	return pnames;
 }
 
-struct ast_schema *newschema(struct arena_info *A, int types)
+struct ast_schema *
+newschema(struct arena_info *A, int types)
 {
-  size_t i,max;
-  struct ast_schema *s;
+	size_t i, max;
+	struct ast_schema *s;
 
-  i = A->nschema++;
-  max = sizeof ar_schema / sizeof ar_schema[0];
-  if (A->nschema >= max) {
-    fprintf(stderr, "too many schema: %zu max\n", max);
-    abort();
-  }
+	i   = A->nschema++;
+	max = sizeof ar_schema / sizeof ar_schema[0];
+	if (A->nschema >= max) {
+		fprintf(stderr, "too many schema: %zu max\n", max);
+		abort();
+	}
 
-  s = &ar_schema[i];
-  memset(s, 0, sizeof *s);
-  s->types = types;
-  return s;
+	s = &ar_schema[i];
+	memset(s, 0, sizeof *s);
+	s->types = types;
+	return s;
 }
 
-struct ast_schema *newschema_p(struct arena_info *A, int types, ...)
+struct ast_schema *
+newschema_p(struct arena_info *A, int types, ...)
 {
-  size_t i,max;
-  struct ast_schema *s;
-  const char *pname;
-  va_list args;
+	size_t i, max;
+	struct ast_schema *s;
+	const char *pname;
+	va_list args;
 
-  i = A->nschema++;
-  max = ARRAYLEN(ar_schema);
-  if (A->nschema >= max) {
-    fprintf(stderr, "too many schema: %zu max\n", max);
-    abort();
-  }
+	i   = A->nschema++;
+	max = ARRAYLEN(ar_schema);
+	if (A->nschema >= max) {
+		fprintf(stderr, "too many schema: %zu max\n", max);
+		abort();
+	}
 
-  s = &ar_schema[i];
-  memset(s, 0, sizeof *s);
-  s->types = types;
+	s = &ar_schema[i];
+	memset(s, 0, sizeof *s);
+	s->types = types;
 
-  va_start(args, types);
-  for(;;) {
-    pname = va_arg(args, const char *);
-    if (pname == NULL) {
-      break;
-    }
+	va_start(args, types);
+	for (;;) {
+		pname = va_arg(args, const char *);
+		if (pname == NULL) {
+			break;
+		}
 
-    // big dumb if-else chain gets the job done...
-    if (strcmp(pname, "minProperties") == 0) {
-      s->kws |= KWS_MINMAX_PROPERTIES;
-      s->min_properties = va_arg(args, ast_count);
-    } else if (strcmp(pname, "maxProperties") == 0) {
-      s->kws |= KWS_MINMAX_PROPERTIES;
-      s->max_properties = va_arg(args, ast_count);
-    } else if (strcmp(pname, "properties") == 0) {
-      s->properties.set = va_arg(args, struct ast_property_schema *);
-    } else if (strcmp(pname, "required") == 0) {
-      s->required.set = va_arg(args, struct ast_string_set *);
-    } else if (strcmp(pname, "minimum") == 0) {
-      s->kws |= KWS_MINIMUM;
-      s->minimum = va_arg(args, double);
-    } else if (strcmp(pname, "dep_strings") == 0) {
-      s->dependencies_strings.set = va_arg(args, struct ast_property_names *);
-    } else if (strcmp(pname, "dep_schema") == 0) {
-      s->dependencies_schema.set = va_arg(args, struct ast_property_schema *);
-    } else if (strcmp(pname, "anyOf") == 0) {
-      struct ast_schema_set *sset;
-      sset = va_arg(args, struct ast_schema_set *);
-      s->some_of.set = sset;
-      s->some_of.min = 1;
-      s->some_of.max = schema_set_count(sset);
-    } else {
-      // okay to abort() a test if the test writer forgot to add a
-      // property to the big dumb if-else chain
-      fprintf(stderr, "unsupported schema properties '%s'\n", pname);
-      abort();
-    }
-  }
-  va_end(args);
+		// big dumb if-else chain gets the job done...
+		if (strcmp(pname, "minProperties") == 0) {
+			s->kws |= KWS_MINMAX_PROPERTIES;
+			s->min_properties = va_arg(args, ast_count);
+		} else if (strcmp(pname, "maxProperties") == 0) {
+			s->kws |= KWS_MINMAX_PROPERTIES;
+			s->max_properties = va_arg(args, ast_count);
+		} else if (strcmp(pname, "properties") == 0) {
+			s->properties.set = va_arg(args, struct ast_property_schema *);
+		} else if (strcmp(pname, "required") == 0) {
+			s->required.set = va_arg(args, struct ast_string_set *);
+		} else if (strcmp(pname, "minimum") == 0) {
+			s->kws |= KWS_MINIMUM;
+			s->minimum = va_arg(args, double);
+		} else if (strcmp(pname, "dep_strings") == 0) {
+			s->dependencies_strings.set = va_arg(args, struct ast_property_names *);
+		} else if (strcmp(pname, "dep_schema") == 0) {
+			s->dependencies_schema.set = va_arg(args, struct ast_property_schema *);
+		} else if (strcmp(pname, "anyOf") == 0) {
+			struct ast_schema_set *sset;
+			sset	   = va_arg(args, struct ast_schema_set *);
+			s->some_of.set = sset;
+			s->some_of.min = 1;
+			s->some_of.max = schema_set_count(sset);
+		} else {
+			// okay to abort() a test if the test writer forgot to add a
+			// property to the big dumb if-else chain
+			fprintf(stderr, "unsupported schema properties '%s'\n", pname);
+			abort();
+		}
+	}
+	va_end(args);
 
-  return s;
+	return s;
 }
 
-struct ast_property_schema *newprops(struct arena_info *A, ...)
+struct ast_property_schema *
+newprops(struct arena_info *A, ...)
 {
-  struct ast_property_schema *props = NULL;
-  struct ast_property_schema **pp = &props;
-  size_t max = sizeof ar_props / sizeof ar_props[0];
-  va_list args;
+	struct ast_property_schema *props = NULL;
+	struct ast_property_schema **pp   = &props;
+	size_t max			  = sizeof ar_props / sizeof ar_props[0];
+	va_list args;
 
-  va_start(args, A);
+	va_start(args, A);
 
-  for(;;) {
-    const char *name;
-    struct ast_schema *schema;
-    struct ast_property_schema *p;
-    size_t i;
+	for (;;) {
+		const char *name;
+		struct ast_schema *schema;
+		struct ast_property_schema *p;
+		size_t i;
 
-    name = va_arg(args, const char *);
-    if (name == NULL) {
-      break;
-    }
+		name = va_arg(args, const char *);
+		if (name == NULL) {
+			break;
+		}
 
-    i = A->nprop++;
-    if (A->nprop >= max) {
-      fprintf(stderr, "too many properties: %zu max\n", max);
-      abort();
-    }
+		i = A->nprop++;
+		if (A->nprop >= max) {
+			fprintf(stderr, "too many properties: %zu max\n", max);
+			abort();
+		}
 
-    p = &ar_props[i];
-    memset(p, 0, sizeof *p);
+		p = &ar_props[i];
+		memset(p, 0, sizeof *p);
 
-    p->pattern.str = newstr(name);
-    p->pattern.dialect = RE_LITERAL;
-    p->schema = va_arg(args, struct ast_schema *);
+		p->pattern.str     = newstr(name);
+		p->pattern.dialect = RE_LITERAL;
+		p->schema	  = va_arg(args, struct ast_schema *);
 
-    *pp = p;
-    pp = &p->next;
-  }
+		*pp = p;
+		pp  = &p->next;
+	}
 
-  va_end(args);
+	va_end(args);
 
-  return props;
+	return props;
 }
 
-const char *jvst_ret2name(int ret)
+const char *
+jvst_ret2name(int ret)
 {
-  switch (ret) {
-  case JVST_INVALID:
-    return "INVALID";
-  case JVST_VALID:
-    return "VALID";
-  case JVST_MORE:
-    return "MORE";
-  default:
-    return "UNKNOWN";
-  }
+	switch (ret) {
+	case JVST_INVALID:
+		return "INVALID";
+	case JVST_VALID:
+		return "VALID";
+	case JVST_MORE:
+		return "MORE";
+	default:
+		return "UNKNOWN";
+	}
 }
 
-struct jvst_cnode *newcnode_valid(void)
+struct jvst_cnode *
+newcnode_valid(void)
 {
-  static struct jvst_cnode n = { .type = JVST_CNODE_VALID };
-  return &n;
+	static struct jvst_cnode n = {.type = JVST_CNODE_VALID};
+	return &n;
 }
 
-struct jvst_cnode *newcnode_invalid(void)
+struct jvst_cnode *
+newcnode_invalid(void)
 {
-  static struct jvst_cnode n = { .type = JVST_CNODE_INVALID };
-  return &n;
+	static struct jvst_cnode n = {.type = JVST_CNODE_INVALID};
+	return &n;
 }
 
-struct jvst_cnode *newcnode(struct arena_info *A, enum jvst_cnode_type type)
+struct jvst_cnode *
+newcnode(struct arena_info *A, enum jvst_cnode_type type)
 {
-  size_t i,max;
-  struct jvst_cnode *node;
-  const char *pname;
-  va_list args;
+	size_t i, max;
+	struct jvst_cnode *node;
+	const char *pname;
+	va_list args;
 
-  i = A->ncnode++;
-  max = ARRAYLEN(ar_cnodes);
-  if (A->ncnode >= max) {
-    fprintf(stderr, "too many cnodes: %zu max\n", max);
-    abort();
-  }
+	i   = A->ncnode++;
+	max = ARRAYLEN(ar_cnodes);
+	if (A->ncnode >= max) {
+		fprintf(stderr, "too many cnodes: %zu max\n", max);
+		abort();
+	}
 
-  node = &ar_cnodes[i];
-  memset(node, 0, sizeof *node);
-  node->type = type;
+	node = &ar_cnodes[i];
+	memset(node, 0, sizeof *node);
+	node->type = type;
 
-  return node;
+	return node;
 }
 
-struct jvst_cnode *newcnode_switch(struct arena_info *A, int isvalid, ...)
+struct jvst_cnode *
+newcnode_switch(struct arena_info *A, int isvalid, ...)
 {
-  struct jvst_cnode *node;
-  size_t i;
-  va_list args;
+	struct jvst_cnode *node;
+	size_t i;
+	va_list args;
 
-  node = newcnode(A, JVST_CNODE_SWITCH);
-  for (i=0; i < SJP_EVENT_MAX; i++) {
-    node->u.sw[i] = isvalid ? newcnode_valid() : newcnode_invalid();
-  }
+	node = newcnode(A, JVST_CNODE_SWITCH);
+	for (i = 0; i < SJP_EVENT_MAX; i++) {
+		node->u.sw[i] = isvalid ? newcnode_valid() : newcnode_invalid();
+	}
 
-  // ARRAY_END and OBJECT_END should not be valid by default...
-  node->u.sw[SJP_ARRAY_END] = newcnode_invalid();
-  node->u.sw[SJP_OBJECT_END] = newcnode_invalid();
+	// ARRAY_END and OBJECT_END should not be valid by default...
+	node->u.sw[SJP_ARRAY_END]  = newcnode_invalid();
+	node->u.sw[SJP_OBJECT_END] = newcnode_invalid();
 
-  va_start(args, isvalid);
-  for(;;) {
-    enum SJP_EVENT evt;
-    struct jvst_cnode *child;
+	va_start(args, isvalid);
+	for (;;) {
+		enum SJP_EVENT evt;
+		struct jvst_cnode *child;
 
-    evt = va_arg(args, enum SJP_EVENT);
-    if (evt == SJP_NONE) {
-      break;
-    }
+		evt = va_arg(args, enum SJP_EVENT);
+		if (evt == SJP_NONE) {
+			break;
+		}
 
-    if (evt >= SJP_EVENT_MAX) {
-      fprintf(stderr, "invalid event %d\n", evt);
-      abort();
-    }
+		if (evt >= SJP_EVENT_MAX) {
+			fprintf(stderr, "invalid event %d\n", evt);
+			abort();
+		}
 
-    child = va_arg(args, struct jvst_cnode *);
-    node->u.sw[evt] = child;
-  }
-  va_end(args);
+		child		= va_arg(args, struct jvst_cnode *);
+		node->u.sw[evt] = child;
+	}
+	va_end(args);
 
-  return node;
+	return node;
 }
 
-struct jvst_cnode *newcnode_bool(struct arena_info *A, enum jvst_cnode_type type, ...)
+struct jvst_cnode *
+newcnode_bool(struct arena_info *A, enum jvst_cnode_type type, ...)
 {
-  struct jvst_cnode *node, **pp;
-  va_list args;
+	struct jvst_cnode *node, **pp;
+	va_list args;
 
-  if ((type != JVST_CNODE_AND) && (type != JVST_CNODE_OR) && (type != JVST_CNODE_XOR)) {
-    fprintf(stderr, "invalid cnode type for %s: %d\n", __func__, type);
-    abort();
-  }
+	if ((type != JVST_CNODE_AND) && (type != JVST_CNODE_OR) && (type != JVST_CNODE_XOR)) {
+		fprintf(stderr, "invalid cnode type for %s: %d\n", __func__, type);
+		abort();
+	}
 
-  node = newcnode(A, type);
-  pp = &node->u.ctrl;
-  *pp = NULL;
+	node = newcnode(A, type);
+	pp   = &node->u.ctrl;
+	*pp  = NULL;
 
-  va_start(args, type);
-  for(;;) {
-    struct jvst_cnode *child;
+	va_start(args, type);
+	for (;;) {
+		struct jvst_cnode *child;
 
-    child = va_arg(args, struct jvst_cnode *);
-    if (child == NULL) {
-      break;
-    }
+		child = va_arg(args, struct jvst_cnode *);
+		if (child == NULL) {
+			break;
+		}
 
-    *pp = child;
-    pp = &child->next;
-  }
-  va_end(args);
+		*pp = child;
+		pp  = &child->next;
+	}
+	va_end(args);
 
-  return node;
+	return node;
 }
 
-struct jvst_cnode *newcnode_propset(struct arena_info *A, ...)
+struct jvst_cnode *
+newcnode_propset(struct arena_info *A, ...)
 {
-  struct jvst_cnode *node, **mlp;
-  va_list args;
+	struct jvst_cnode *node, **mlp;
+	va_list args;
 
-  node = newcnode(A, JVST_CNODE_OBJ_PROP_SET);
-  mlp = &node->u.prop_set;
-  *mlp = NULL;
+	node = newcnode(A, JVST_CNODE_OBJ_PROP_SET);
+	mlp  = &node->u.prop_set;
+	*mlp = NULL;
 
-  va_start(args, A);
-  for(;;) {
-    struct jvst_cnode *match;
-    match = va_arg(args, struct jvst_cnode *);
-    if (match == NULL) {
-      break;
-    }
-    *mlp = match;
-    mlp = &(*mlp)->next;
-  }
-  va_end(args);
+	va_start(args, A);
+	for (;;) {
+		struct jvst_cnode *match;
+		match = va_arg(args, struct jvst_cnode *);
+		if (match == NULL) {
+			break;
+		}
+		*mlp = match;
+		mlp  = &(*mlp)->next;
+	}
+	va_end(args);
 
-  return node;
+	return node;
 }
 
-struct jvst_cnode *newcnode_prop_match(struct arena_info *A,
-    enum re_dialect dialect, const char *pat, struct jvst_cnode *constraint)
+struct jvst_cnode *
+newcnode_prop_match(struct arena_info *A, enum re_dialect dialect, const char *pat,
+		    struct jvst_cnode *constraint)
 {
-  struct jvst_cnode *node;
+	struct jvst_cnode *node;
 
-  node = newcnode(A, JVST_CNODE_OBJ_PROP_MATCH);
+	node = newcnode(A, JVST_CNODE_OBJ_PROP_MATCH);
 
-  node->u.prop_match.match.dialect = dialect;
-  node->u.prop_match.match.str = newstr(pat);
-  node->u.prop_match.match.fsm = NULL;
-  node->u.prop_match.constraint = constraint;
+	node->u.prop_match.match.dialect = dialect;
+	node->u.prop_match.match.str     = newstr(pat);
+	node->u.prop_match.match.fsm     = NULL;
+	node->u.prop_match.constraint    = constraint;
 
-  return node;
+	return node;
 }
 
-struct jvst_cnode *newcnode_range(struct arena_info *A,
-    enum jvst_cnode_rangeflags flags, double min, double max)
+struct jvst_cnode *
+newcnode_range(struct arena_info *A, enum jvst_cnode_rangeflags flags, double min, double max)
 {
-  struct jvst_cnode *node, **pp;
-  node = newcnode(A, JVST_CNODE_NUM_RANGE);
-  node->u.num_range.flags = flags;
-  node->u.num_range.min = min;
-  node->u.num_range.max = max;
-  return node;
+	struct jvst_cnode *node, **pp;
+	node			= newcnode(A, JVST_CNODE_NUM_RANGE);
+	node->u.num_range.flags = flags;
+	node->u.num_range.min   = min;
+	node->u.num_range.max   = max;
+	return node;
 }
 
-struct jvst_cnode *newcnode_counts(struct arena_info *A, size_t min, size_t max)
+struct jvst_cnode *
+newcnode_counts(struct arena_info *A, size_t min, size_t max)
 {
-  struct jvst_cnode *node, **pp;
-  node = newcnode(A, JVST_CNODE_COUNT_RANGE);
-  node->u.counts.min = min;
-  node->u.counts.max = max;
-  return node;
+	struct jvst_cnode *node, **pp;
+	node		   = newcnode(A, JVST_CNODE_COUNT_RANGE);
+	node->u.counts.min = min;
+	node->u.counts.max = max;
+	return node;
 }
 
-struct jvst_cnode *newcnode_required(struct arena_info *A, struct ast_string_set *sset)
+struct jvst_cnode *
+newcnode_required(struct arena_info *A, struct ast_string_set *sset)
 {
-  struct ast_string_set **spp;
-  struct jvst_cnode *node;
-  va_list args;
+	struct ast_string_set **spp;
+	struct jvst_cnode *node;
+	va_list args;
 
-  node = newcnode(A, JVST_CNODE_OBJ_REQUIRED);
-  node->u.required = sset;
+	node		 = newcnode(A, JVST_CNODE_OBJ_REQUIRED);
+	node->u.required = sset;
 
-  return node;
+	return node;
 }
-

--- a/src/validate_testing.c
+++ b/src/validate_testing.c
@@ -342,7 +342,6 @@ newcnode(struct arena_info *A, enum jvst_cnode_type type)
 	size_t i, max;
 	struct jvst_cnode *node;
 	const char *pname;
-	va_list args;
 
 	i   = A->ncnode++;
 	max = ARRAYLEN(ar_cnodes);
@@ -474,7 +473,7 @@ struct jvst_cnode *
 newcnode_range(struct arena_info *A, enum jvst_cnode_rangeflags flags, double min, double max)
 {
 	struct jvst_cnode *node, **pp;
-	node			= newcnode(A, JVST_CNODE_NUM_RANGE);
+	node = newcnode(A, JVST_CNODE_NUM_RANGE);
 	node->u.num_range.flags = flags;
 	node->u.num_range.min   = min;
 	node->u.num_range.max   = max;
@@ -485,7 +484,7 @@ struct jvst_cnode *
 newcnode_counts(struct arena_info *A, size_t min, size_t max)
 {
 	struct jvst_cnode *node, **pp;
-	node		   = newcnode(A, JVST_CNODE_COUNT_RANGE);
+	node = newcnode(A, JVST_CNODE_COUNT_RANGE);
 	node->u.counts.min = min;
 	node->u.counts.max = max;
 	return node;
@@ -498,8 +497,10 @@ newcnode_required(struct arena_info *A, struct ast_string_set *sset)
 	struct jvst_cnode *node;
 	va_list args;
 
-	node		 = newcnode(A, JVST_CNODE_OBJ_REQUIRED);
+	node = newcnode(A, JVST_CNODE_OBJ_REQUIRED);
 	node->u.required = sset;
 
 	return node;
 }
+
+/* vim: set tabstop=8 shiftwidth=8 noexpandtab: */

--- a/src/validate_testing.c
+++ b/src/validate_testing.c
@@ -236,14 +236,26 @@ newschema_p(struct arena_info *A, int types, ...)
 			s->dependencies_schema.set = va_arg(args, struct ast_property_schema *);
 		} else if (strcmp(pname, "anyOf") == 0) {
 			struct ast_schema_set *sset;
-			sset	   = va_arg(args, struct ast_schema_set *);
+			sset = va_arg(args, struct ast_schema_set *);
 			s->some_of.set = sset;
 			s->some_of.min = 1;
 			s->some_of.max = schema_set_count(sset);
+		} else if (strcmp(pname, "allOf") == 0) {
+			struct ast_schema_set *sset;
+			sset = va_arg(args, struct ast_schema_set *);
+			s->some_of.set = sset;
+			s->some_of.min = schema_set_count(sset);
+			s->some_of.max = s->some_of.min;
+		} else if (strcmp(pname, "oneOf") == 0) {
+			struct ast_schema_set *sset;
+			sset = va_arg(args, struct ast_schema_set *);
+			s->some_of.set = sset;
+			s->some_of.min = 1;
+			s->some_of.max = 1;
 		} else {
 			// okay to abort() a test if the test writer forgot to add a
 			// property to the big dumb if-else chain
-			fprintf(stderr, "unsupported schema properties '%s'\n", pname);
+			fprintf(stderr, "unsupported schema property '%s'\n", pname);
 			abort();
 		}
 	}

--- a/src/validate_testing.c
+++ b/src/validate_testing.c
@@ -221,6 +221,10 @@ struct ast_schema *newschema_p(struct arena_info *A, int types, ...)
     } else if (strcmp(pname, "minimum") == 0) {
       s->kws |= KWS_MINIMUM;
       s->minimum = va_arg(args, double);
+    } else if (strcmp(pname, "dep_strings") == 0) {
+      s->dependencies_strings.set = va_arg(args, struct ast_property_names *);
+    } else if (strcmp(pname, "dep_schema") == 0) {
+      s->dependencies_schema.set = va_arg(args, struct ast_property_schema *);
     } else if (strcmp(pname, "anyOf") == 0) {
       struct ast_schema_set *sset;
       sset = va_arg(args, struct ast_schema_set *);

--- a/src/validate_testing.c
+++ b/src/validate_testing.c
@@ -311,7 +311,7 @@ struct jvst_cnode *newcnode_invalid(void)
   return &n;
 }
 
-struct jvst_cnode *newcnode(struct arena_info *A, enum JVST_CNODE_TYPE type)
+struct jvst_cnode *newcnode(struct arena_info *A, enum jvst_cnode_type type)
 {
   size_t i,max;
   struct jvst_cnode *node;
@@ -370,7 +370,7 @@ struct jvst_cnode *newcnode_switch(struct arena_info *A, int isvalid, ...)
   return node;
 }
 
-struct jvst_cnode *newcnode_bool(struct arena_info *A, enum JVST_CNODE_TYPE type, ...)
+struct jvst_cnode *newcnode_bool(struct arena_info *A, enum jvst_cnode_type type, ...)
 {
   struct jvst_cnode *node, **pp;
   va_list args;
@@ -441,7 +441,7 @@ struct jvst_cnode *newcnode_prop_match(struct arena_info *A,
 }
 
 struct jvst_cnode *newcnode_range(struct arena_info *A,
-    enum JVST_CNODE_RANGEFLAGS flags, double min, double max)
+    enum jvst_cnode_rangeflags flags, double min, double max)
 {
   struct jvst_cnode *node, **pp;
   node = newcnode(A, JVST_CNODE_NUM_RANGE);

--- a/src/validate_testing.h
+++ b/src/validate_testing.h
@@ -29,6 +29,21 @@ struct ast_property_schema *newprops(struct arena_info *A, ...);
 struct jvst_cnode *newcnode(struct arena_info *A, enum JVST_CNODE_TYPE type);
 struct jvst_cnode *newcnode_switch(struct arena_info *A, int isvalid, ...);
 
+struct jvst_cnode *newcnode_prop_match(struct arena_info *A,
+    enum re_dialect dialect, const char *pat, struct jvst_cnode *constraint);
+
+struct jvst_cnode *newcnode_bool(struct arena_info *A, enum JVST_CNODE_TYPE type, ...);
+
+struct jvst_cnode *newcnode_range(struct arena_info *A,
+    enum JVST_CNODE_RANGEFLAGS flags, double min, double max);
+
+struct jvst_cnode *newcnode_counts(struct arena_info *A, size_t min, size_t max);
+
+struct jvst_cnode *newcnode_valid(void);
+struct jvst_cnode *newcnode_invalid(void);
+
+struct jvst_cnode *newcnode_required(struct arena_info *A, struct ast_string_set *sset);
+
 const char *jvst_ret2name(int ret);
 
 static inline int report_tests(void)

--- a/src/validate_testing.h
+++ b/src/validate_testing.h
@@ -9,55 +9,83 @@ extern int ntest;
 extern int nfail;
 
 struct arena_info {
-  size_t nschema;
-  size_t nprop;
-  size_t nstr;
-  size_t npnames;
-  size_t nset;
-  size_t ncnode;
+	size_t nschema;
+	size_t nprop;
+	size_t nstr;
+	size_t npnames;
+	size_t nset;
+	size_t ncnode;
 };
 
-struct ast_schema *empty_schema(void);
-struct ast_schema *newschema(struct arena_info *A, int types);
-struct ast_schema *newschema_p(struct arena_info *A, int types, ...);
+struct ast_schema *
+empty_schema(void);
 
-struct json_string newstr(const char *s);
-struct ast_string_set *stringset(struct arena_info *A, ...);
-struct ast_schema_set *schema_set(struct arena_info *A, ...);
-size_t schema_set_count(struct ast_schema_set *s);
-struct ast_property_schema *newprops(struct arena_info *A, ...);
-struct ast_property_names *newpropnames(struct arena_info *A, ...);
+struct ast_schema *
+newschema(struct arena_info *A, int types);
 
-struct jvst_cnode *newcnode(struct arena_info *A, enum jvst_cnode_type type);
-struct jvst_cnode *newcnode_switch(struct arena_info *A, int isvalid, ...);
+struct ast_schema *
+newschema_p(struct arena_info *A, int types, ...);
 
-struct jvst_cnode *newcnode_prop_match(struct arena_info *A,
-    enum re_dialect dialect, const char *pat, struct jvst_cnode *constraint);
+struct json_string
+newstr(const char *s);
 
-struct jvst_cnode *newcnode_propset(struct arena_info *A, ...);
+struct ast_string_set *
+stringset(struct arena_info *A, ...);
 
-struct jvst_cnode *newcnode_bool(struct arena_info *A, enum jvst_cnode_type type, ...);
+struct ast_schema_set *
+schema_set(struct arena_info *A, ...);
 
-struct jvst_cnode *newcnode_range(struct arena_info *A,
-    enum jvst_cnode_rangeflags flags, double min, double max);
+size_t
+schema_set_count(struct ast_schema_set *s);
 
-struct jvst_cnode *newcnode_counts(struct arena_info *A, size_t min, size_t max);
+struct ast_property_schema *
+newprops(struct arena_info *A, ...);
 
-struct jvst_cnode *newcnode_valid(void);
-struct jvst_cnode *newcnode_invalid(void);
+struct ast_property_names *
+newpropnames(struct arena_info *A, ...);
 
-struct jvst_cnode *newcnode_required(struct arena_info *A, struct ast_string_set *sset);
+struct jvst_cnode *
+newcnode(struct arena_info *A, enum jvst_cnode_type type);
 
-const char *jvst_ret2name(int ret);
+struct jvst_cnode *
+newcnode_switch(struct arena_info *A, int isvalid, ...);
 
-static inline int report_tests(void)
+struct jvst_cnode *
+newcnode_prop_match(struct arena_info *A, enum re_dialect dialect, const char *pat,
+		    struct jvst_cnode *constraint);
+
+struct jvst_cnode *
+newcnode_propset(struct arena_info *A, ...);
+
+struct jvst_cnode *
+newcnode_bool(struct arena_info *A, enum jvst_cnode_type type, ...);
+
+struct jvst_cnode *
+newcnode_range(struct arena_info *A, enum jvst_cnode_rangeflags flags, double min, double max);
+
+struct jvst_cnode *
+newcnode_counts(struct arena_info *A, size_t min, size_t max);
+
+struct jvst_cnode *
+newcnode_valid(void);
+
+struct jvst_cnode *
+newcnode_invalid(void);
+
+struct jvst_cnode *
+newcnode_required(struct arena_info *A, struct ast_string_set *sset);
+
+const char *
+jvst_ret2name(int ret);
+
+static inline int
+report_tests(void)
 {
-  printf("%d tests, %d failures\n", ntest, nfail);
-  if (nfail == 0 && ntest > 0) {
-    return EXIT_SUCCESS;
-  }
-  return EXIT_FAILURE;
+	printf("%d tests, %d failures\n", ntest, nfail);
+	if (nfail == 0 && ntest > 0) {
+		return EXIT_SUCCESS;
+	}
+	return EXIT_FAILURE;
 }
 
 #endif /* TESTING_H */
-

--- a/src/validate_testing.h
+++ b/src/validate_testing.h
@@ -28,7 +28,7 @@ size_t schema_set_count(struct ast_schema_set *s);
 struct ast_property_schema *newprops(struct arena_info *A, ...);
 struct ast_property_names *newpropnames(struct arena_info *A, ...);
 
-struct jvst_cnode *newcnode(struct arena_info *A, enum JVST_CNODE_TYPE type);
+struct jvst_cnode *newcnode(struct arena_info *A, enum jvst_cnode_type type);
 struct jvst_cnode *newcnode_switch(struct arena_info *A, int isvalid, ...);
 
 struct jvst_cnode *newcnode_prop_match(struct arena_info *A,
@@ -36,10 +36,10 @@ struct jvst_cnode *newcnode_prop_match(struct arena_info *A,
 
 struct jvst_cnode *newcnode_propset(struct arena_info *A, ...);
 
-struct jvst_cnode *newcnode_bool(struct arena_info *A, enum JVST_CNODE_TYPE type, ...);
+struct jvst_cnode *newcnode_bool(struct arena_info *A, enum jvst_cnode_type type, ...);
 
 struct jvst_cnode *newcnode_range(struct arena_info *A,
-    enum JVST_CNODE_RANGEFLAGS flags, double min, double max);
+    enum jvst_cnode_rangeflags flags, double min, double max);
 
 struct jvst_cnode *newcnode_counts(struct arena_info *A, size_t min, size_t max);
 

--- a/src/validate_testing.h
+++ b/src/validate_testing.h
@@ -89,3 +89,5 @@ report_tests(void)
 }
 
 #endif /* TESTING_H */
+
+/* vim: set tabstop=8 shiftwidth=8 noexpandtab: */

--- a/src/validate_testing.h
+++ b/src/validate_testing.h
@@ -3,6 +3,7 @@
 
 #include "jdom.h"
 #include "ast.h"
+#include "validate_constraints.h"
 
 extern int ntest;
 extern int nfail;
@@ -12,6 +13,7 @@ struct arena_info {
   size_t nprop;
   size_t nstr;
   size_t nset;
+  size_t ncnode;
 };
 
 struct ast_schema *empty_schema(void);
@@ -23,6 +25,9 @@ struct ast_string_set *stringset(struct arena_info *A, ...);
 struct ast_schema_set *schema_set(struct arena_info *A, ...);
 size_t schema_set_count(struct ast_schema_set *s);
 struct ast_property_schema *newprops(struct arena_info *A, ...);
+
+struct jvst_cnode *newcnode(struct arena_info *A, enum JVST_CNODE_TYPE type);
+struct jvst_cnode *newcnode_switch(struct arena_info *A, int isvalid, ...);
 
 const char *jvst_ret2name(int ret);
 

--- a/src/validate_testing.h
+++ b/src/validate_testing.h
@@ -12,6 +12,7 @@ struct arena_info {
   size_t nschema;
   size_t nprop;
   size_t nstr;
+  size_t npnames;
   size_t nset;
   size_t ncnode;
 };
@@ -25,12 +26,15 @@ struct ast_string_set *stringset(struct arena_info *A, ...);
 struct ast_schema_set *schema_set(struct arena_info *A, ...);
 size_t schema_set_count(struct ast_schema_set *s);
 struct ast_property_schema *newprops(struct arena_info *A, ...);
+struct ast_property_names *newpropnames(struct arena_info *A, ...);
 
 struct jvst_cnode *newcnode(struct arena_info *A, enum JVST_CNODE_TYPE type);
 struct jvst_cnode *newcnode_switch(struct arena_info *A, int isvalid, ...);
 
 struct jvst_cnode *newcnode_prop_match(struct arena_info *A,
     enum re_dialect dialect, const char *pat, struct jvst_cnode *constraint);
+
+struct jvst_cnode *newcnode_propset(struct arena_info *A, ...);
 
 struct jvst_cnode *newcnode_bool(struct arena_info *A, enum JVST_CNODE_TYPE type, ...);
 


### PR DESCRIPTION
Adds code to convert AST into a tree of simpler constraint nodes and then simplify that tree into a more canonical form that can be more easily translated into a simple intermediate representation.
