### PR TITLE
cnode property simplifications

### DIFF
--- a/src/test_constraints.c
+++ b/src/test_constraints.c
@@ -1198,13 +1198,6 @@ void test_simplify_propsets(void)
     { STOP },
   };
 
-#if 0
-  jvst_cnode_print(tests[0].expected);
-  fprintf(stderr, "\n\n");
-  jvst_cnode_print(tests[1].expected);
-  fprintf(stderr, "\n\n");
-#endif /* 0 */
-
   RUNTESTS(tests);
 }
 

--- a/src/test_ir.c
+++ b/src/test_ir.c
@@ -161,6 +161,7 @@ static int ir_trees_equal(const char *fname, struct jvst_ir_stmt *n1, struct jvs
   return 0;
 }
 
+#define UNIMPLEMENTED(testlist) do{ nskipped++; (void)testlist; }while(0)
 #define RUNTESTS(testlist) runtests(__func__, (testlist))
 static void runtests(const char *testname, const struct ir_test tests[])
 {
@@ -495,6 +496,23 @@ void test_ir_properties(void)
   RUNTESTS(tests);
 }
 
+/* incomplete tests... placeholders for conversion from cnode tests */
+static void test_ir_minproperties_1(void);
+static void test_ir_minproperties_2(void);
+static void test_ir_minproperties_3(void);
+static void test_ir_maxproperties_1(void);
+static void test_ir_maxproperties_2(void);
+static void test_ir_minmaxproperties_1(void);
+
+static void test_ir_required(void);
+static void test_ir_dependencies(void);
+
+static void test_ir_anyof_allof_oneof_1(void);
+static void test_ir_anyof_2(void);
+
+static void test_ir_simplify_ands(void);
+static void test_ir_simplify_ored_schema(void);
+
 int main(void)
 {
   test_ir_empty_schema();
@@ -505,7 +523,7 @@ int main(void)
 
   test_ir_properties();
 
-#if 0
+  /* incomplete tests... placeholders for conversion from cnode tests */
   test_ir_minproperties_1();
   test_ir_minproperties_2();
   test_ir_minproperties_3();
@@ -519,55 +537,44 @@ int main(void)
   test_ir_anyof_allof_oneof_1();
   test_ir_anyof_2();
 
-  test_simplify_ands();
-  test_simplify_ored_schema();
-#endif /* 0 */
+  test_ir_simplify_ands();
+  test_ir_simplify_ored_schema();
 
   return report_tests();
 }
 
-#if 0
-void test_xlate_minproperties_1(void)
+/* incomplete tests... placeholders for conversion from cnode tests */
+void test_ir_minproperties_1(void)
 {
   struct arena_info A = {0};
-  struct ast_schema *schema = newschema_p(&A, 0,
-      "minProperties", 1,
-      NULL);
 
   // initial schema is not reduced (additional constraints are ANDed
   // together).  Reduction will occur on a later pass.
-  const struct cnode_test tests[] = {
+  const struct ir_test tests[] = {
     {
-      TRANSLATE, schema, NULL,
         newcnode_switch(&A, 1,
           SJP_OBJECT_BEG, newcnode_bool(&A,JVST_CNODE_AND,
                             newcnode_counts(&A, 1, 0),
                             newcnode_valid(),
                             NULL),
           SJP_NONE),
+
+        NULL,
     },
-    { STOP },
+    { NULL },
   };
 
-  RUNTESTS(tests);
+  UNIMPLEMENTED(tests);
 }
 
-void test_xlate_minproperties_2(void)
+void test_ir_minproperties_2(void)
 {
   struct arena_info A = {0};
-  struct ast_schema *schema = newschema_p(&A, 0,
-      "minProperties", 1,
-      "properties", newprops(&A,
-        "foo", newschema(&A, JSON_VALUE_NUMBER), // XXX - JSON_VALUE_INTEGER
-        "bar", newschema(&A, JSON_VALUE_STRING),
-        NULL),
-      NULL);
 
   // initial schema is not reduced (additional constraints are ANDed
   // together).  Reduction will occur on a later pass.
-  const struct cnode_test tests[] = {
+  const struct ir_test tests[] = {
     {
-      TRANSLATE, schema, NULL,
         newcnode_switch(&A, 1,
           SJP_OBJECT_BEG, newcnode_bool(&A,JVST_CNODE_AND,
                             newcnode_counts(&A, 1, 0),
@@ -582,14 +589,17 @@ void test_xlate_minproperties_2(void)
                               NULL),
                             NULL),
           SJP_NONE),
+
+        NULL
     },
-    { STOP },
+
+    { NULL },
   };
 
-  RUNTESTS(tests);
+  UNIMPLEMENTED(tests);
 }
 
-void test_xlate_minproperties_3(void)
+void test_ir_minproperties_3(void)
 {
   struct arena_info A = {0};
   struct ast_schema *schema = newschema_p(&A, 0,
@@ -604,36 +614,38 @@ void test_xlate_minproperties_3(void)
 
   // initial schema is not reduced (additional constraints are ANDed
   // together).  Reduction will occur on a later pass.
-  const struct cnode_test tests[] = {
+  const struct ir_test tests[] = {
     {
-      TRANSLATE, schema, NULL,
-        newcnode_switch(&A, 1,
-          SJP_OBJECT_BEG, newcnode_bool(&A,JVST_CNODE_AND,
-                            newcnode_counts(&A, 1, 0),
-                            newcnode_bool(&A,JVST_CNODE_AND,
-                              newcnode_propset(&A,
-                                newcnode_prop_match(&A, RE_LITERAL, "foo",
-                                  newcnode_switch(&A, 0,
-                                    SJP_OBJECT_BEG, newcnode_bool(&A,JVST_CNODE_AND,
-                                                      newcnode_counts(&A, 1, 0),
-                                                      newcnode_valid(),
-                                                      NULL),
-                                    SJP_NONE)),
-                                newcnode_prop_match(&A, RE_LITERAL, "bar",
-                                  newcnode_switch(&A, 0, SJP_STRING, newcnode_valid(), SJP_NONE)),
-                                NULL),
-                              newcnode_valid(),
+      newcnode_switch(&A, 1,
+        SJP_OBJECT_BEG, newcnode_bool(&A,JVST_CNODE_AND,
+                          newcnode_counts(&A, 1, 0),
+                          newcnode_bool(&A,JVST_CNODE_AND,
+                            newcnode_propset(&A,
+                              newcnode_prop_match(&A, RE_LITERAL, "foo",
+                                newcnode_switch(&A, 0,
+                                  SJP_OBJECT_BEG, newcnode_bool(&A,JVST_CNODE_AND,
+                                                    newcnode_counts(&A, 1, 0),
+                                                    newcnode_valid(),
+                                                    NULL),
+                                  SJP_NONE)),
+                              newcnode_prop_match(&A, RE_LITERAL, "bar",
+                                newcnode_switch(&A, 0, SJP_STRING, newcnode_valid(), SJP_NONE)),
                               NULL),
+                            newcnode_valid(),
                             NULL),
-          SJP_NONE),
+                          NULL),
+        SJP_NONE),
+
+      NULL
     },
-    { STOP },
+
+    { NULL },
   };
 
-  RUNTESTS(tests);
+  UNIMPLEMENTED(tests);
 }
 
-void test_xlate_maxproperties_1(void)
+void test_ir_maxproperties_1(void)
 {
   struct arena_info A = {0};
   struct ast_schema *schema = newschema_p(&A, 0,
@@ -642,23 +654,25 @@ void test_xlate_maxproperties_1(void)
 
   // initial schema is not reduced (additional constraints are ANDed
   // together).  Reduction will occur on a later pass.
-  const struct cnode_test tests[] = {
+  const struct ir_test tests[] = {
     {
-      TRANSLATE, schema, NULL,
-        newcnode_switch(&A, 1,
-          SJP_OBJECT_BEG, newcnode_bool(&A,JVST_CNODE_AND,
-                            newcnode_counts(&A, 0, 2),
-                            newcnode_valid(),
-                            NULL),
-          SJP_NONE),
+      newcnode_switch(&A, 1,
+        SJP_OBJECT_BEG, newcnode_bool(&A,JVST_CNODE_AND,
+                          newcnode_counts(&A, 0, 2),
+                          newcnode_valid(),
+                          NULL),
+        SJP_NONE),
+
+      NULL
     },
-    { STOP },
+
+    { NULL },
   };
 
-  RUNTESTS(tests);
+  UNIMPLEMENTED(tests);
 }
 
-void test_xlate_maxproperties_2(void)
+void test_ir_maxproperties_2(void)
 {
   struct arena_info A = {0};
   struct ast_schema *schema = newschema_p(&A, 0,
@@ -673,36 +687,38 @@ void test_xlate_maxproperties_2(void)
 
   // initial schema is not reduced (additional constraints are ANDed
   // together).  Reduction will occur on a later pass.
-  const struct cnode_test tests[] = {
+  const struct ir_test tests[] = {
     {
-      TRANSLATE, schema, NULL,
-        newcnode_switch(&A, 1,
-          SJP_OBJECT_BEG, newcnode_bool(&A,JVST_CNODE_AND,
-                            newcnode_counts(&A, 0, 1),
-                            newcnode_bool(&A,JVST_CNODE_AND,
-                              newcnode_propset(&A,
-                                newcnode_prop_match(&A, RE_LITERAL, "foo",
-                                  newcnode_switch(&A, 0,
-                                    SJP_OBJECT_BEG, newcnode_bool(&A,JVST_CNODE_AND,
-                                                      newcnode_counts(&A, 0, 1),
-                                                      newcnode_valid(),
-                                                      NULL),
-                                    SJP_NONE)),
-                                newcnode_prop_match(&A, RE_LITERAL, "bar",
-                                  newcnode_switch(&A, 0, SJP_STRING, newcnode_valid(), SJP_NONE)),
-                                NULL),
-                              newcnode_valid(),
+      newcnode_switch(&A, 1,
+        SJP_OBJECT_BEG, newcnode_bool(&A,JVST_CNODE_AND,
+                          newcnode_counts(&A, 0, 1),
+                          newcnode_bool(&A,JVST_CNODE_AND,
+                            newcnode_propset(&A,
+                              newcnode_prop_match(&A, RE_LITERAL, "foo",
+                                newcnode_switch(&A, 0,
+                                  SJP_OBJECT_BEG, newcnode_bool(&A,JVST_CNODE_AND,
+                                                    newcnode_counts(&A, 0, 1),
+                                                    newcnode_valid(),
+                                                    NULL),
+                                  SJP_NONE)),
+                              newcnode_prop_match(&A, RE_LITERAL, "bar",
+                                newcnode_switch(&A, 0, SJP_STRING, newcnode_valid(), SJP_NONE)),
                               NULL),
+                            newcnode_valid(),
                             NULL),
-          SJP_NONE),
+                          NULL),
+        SJP_NONE),
+
+      NULL
     },
-    { STOP },
+
+    { NULL },
   };
 
-  RUNTESTS(tests);
+  UNIMPLEMENTED(tests);
 }
 
-void test_xlate_minmaxproperties_1(void)
+void test_ir_minmaxproperties_1(void)
 {
   struct arena_info A = {0};
   struct ast_schema *schema = newschema_p(&A, 0,
@@ -719,36 +735,38 @@ void test_xlate_minmaxproperties_1(void)
 
   // initial schema is not reduced (additional constraints are ANDed
   // together).  Reduction will occur on a later pass.
-  const struct cnode_test tests[] = {
+  const struct ir_test tests[] = {
     {
-      TRANSLATE, schema, NULL,
-        newcnode_switch(&A, 1,
-          SJP_OBJECT_BEG, newcnode_bool(&A,JVST_CNODE_AND,
-                            newcnode_counts(&A, 1, 1),
-                            newcnode_bool(&A,JVST_CNODE_AND,
-                              newcnode_propset(&A,
-                                newcnode_prop_match(&A, RE_LITERAL, "foo",
-                                  newcnode_switch(&A, 0,
-                                    SJP_OBJECT_BEG, newcnode_bool(&A,JVST_CNODE_AND,
-                                                      newcnode_counts(&A, 1, 2),
-                                                      newcnode_valid(),
-                                                      NULL),
-                                    SJP_NONE)),
-                                newcnode_prop_match(&A, RE_LITERAL, "bar",
-                                  newcnode_switch(&A, 0, SJP_STRING, newcnode_valid(), SJP_NONE)),
-                                NULL),
-                              newcnode_valid(),
+      newcnode_switch(&A, 1,
+        SJP_OBJECT_BEG, newcnode_bool(&A,JVST_CNODE_AND,
+                          newcnode_counts(&A, 1, 1),
+                          newcnode_bool(&A,JVST_CNODE_AND,
+                            newcnode_propset(&A,
+                              newcnode_prop_match(&A, RE_LITERAL, "foo",
+                                newcnode_switch(&A, 0,
+                                  SJP_OBJECT_BEG, newcnode_bool(&A,JVST_CNODE_AND,
+                                                    newcnode_counts(&A, 1, 2),
+                                                    newcnode_valid(),
+                                                    NULL),
+                                  SJP_NONE)),
+                              newcnode_prop_match(&A, RE_LITERAL, "bar",
+                                newcnode_switch(&A, 0, SJP_STRING, newcnode_valid(), SJP_NONE)),
                               NULL),
+                            newcnode_valid(),
                             NULL),
-          SJP_NONE),
+                          NULL),
+        SJP_NONE),
+
+      NULL
     },
-    { STOP },
+
+    { NULL },
   };
 
-  RUNTESTS(tests);
+  UNIMPLEMENTED(tests);
 }
 
-void test_xlate_required(void)
+void test_ir_required(void)
 {
   struct arena_info A = {0};
   struct ast_schema *schema = newschema_p(&A, 0,
@@ -761,44 +779,37 @@ void test_xlate_required(void)
 
   // initial schema is not reduced (additional constraints are ANDed
   // together).  Reduction will occur on a later pass.
-  const struct cnode_test tests[] = {
+  const struct ir_test tests[] = {
     {
-      TRANSLATE, schema, NULL,
-        newcnode_switch(&A, 1,
-          SJP_OBJECT_BEG, newcnode_bool(&A,JVST_CNODE_AND,
-                            newcnode_required(&A, stringset(&A, "foo", NULL)),
-                            newcnode_bool(&A,JVST_CNODE_AND,
-                              newcnode_propset(&A,
-                                newcnode_prop_match(&A, RE_LITERAL, "foo", newcnode_switch(&A, 1, SJP_NONE)),
-                                newcnode_prop_match(&A, RE_LITERAL, "bar", newcnode_switch(&A, 1, SJP_NONE)),
-                                NULL),
-                              newcnode_valid(),
+      newcnode_switch(&A, 1,
+        SJP_OBJECT_BEG, newcnode_bool(&A,JVST_CNODE_AND,
+                          newcnode_required(&A, stringset(&A, "foo", NULL)),
+                          newcnode_bool(&A,JVST_CNODE_AND,
+                            newcnode_propset(&A,
+                              newcnode_prop_match(&A, RE_LITERAL, "foo", newcnode_switch(&A, 1, SJP_NONE)),
+                              newcnode_prop_match(&A, RE_LITERAL, "bar", newcnode_switch(&A, 1, SJP_NONE)),
                               NULL),
+                            newcnode_valid(),
                             NULL),
-          SJP_NONE),
+                          NULL),
+        SJP_NONE),
     },
-    { STOP },
+
+    { NULL },
   };
 
-  RUNTESTS(tests);
+  UNIMPLEMENTED(tests);
 }
 
-void test_xlate_dependencies(void)
+void test_ir_dependencies(void)
 {
   struct arena_info A = {0};
 
   // initial schema is not reduced (additional constraints are ANDed
   // together).  Reduction will occur on a later pass.
-  const struct cnode_test tests[] = {
+  const struct ir_test tests[] = {
     {
-      TRANSLATE, 
       // schema: { "dependencies": {"bar": ["foo"]} }
-      newschema_p(&A, 0,
-          "dep_strings", newpropnames(&A, "bar", stringset(&A, "foo", NULL), NULL),
-          NULL),
-
-      NULL,
-
       newcnode_switch(&A, 1,
         SJP_OBJECT_BEG, newcnode_bool(&A, JVST_CNODE_AND,
                           newcnode_bool(&A, JVST_CNODE_OR,
@@ -810,17 +821,12 @@ void test_xlate_dependencies(void)
                           newcnode_valid(),
                           NULL),
         SJP_NONE),
+
+      NULL
     },
 
     {
-      TRANSLATE, 
       // schema: { "dependencies": {"quux": ["foo", "bar"]} }
-      newschema_p(&A, 0,
-          "dep_strings", newpropnames(&A, "quux", stringset(&A, "foo", "bar", NULL), NULL),
-          NULL),
-
-      NULL,
-
       newcnode_switch(&A, 1,
         SJP_OBJECT_BEG, newcnode_bool(&A, JVST_CNODE_AND,
                           newcnode_bool(&A, JVST_CNODE_OR,
@@ -832,20 +838,12 @@ void test_xlate_dependencies(void)
                           newcnode_valid(),
                           NULL),
         SJP_NONE),
+
+      NULL
     },
 
     {
-      TRANSLATE, 
       // schema: { "dependencies": {"quux": ["foo", "bar"], "this": ["that"]} }
-      newschema_p(&A, 0,
-          "dep_strings", newpropnames(&A,
-                           "quux", stringset(&A, "foo", "bar", NULL),
-                           "this", stringset(&A, "that", NULL),
-                           NULL),
-          NULL),
-
-      NULL,
-
       newcnode_switch(&A, 1,
         SJP_OBJECT_BEG, newcnode_bool(&A, JVST_CNODE_AND,
                           newcnode_bool(&A, JVST_CNODE_OR,
@@ -863,10 +861,11 @@ void test_xlate_dependencies(void)
                           newcnode_valid(),
                           NULL),
         SJP_NONE),
+
+      NULL
     },
 
     {
-      TRANSLATE, 
       // schema: { "dependencies": {"quux": ["foo", "bar"]} }
       // schema: {
       //   "dependencies": {
@@ -878,19 +877,6 @@ void test_xlate_dependencies(void)
       //     }
       //   }
       // },
-      newschema_p(&A, 0,
-          "dep_schema",
-          newprops(&A, "bar", newschema_p(&A, 0,
-                                "properties", newprops(&A,
-                                  "foo", newschema(&A, JSON_VALUE_INTEGER),
-                                  "bar", newschema(&A, JSON_VALUE_INTEGER),
-                                  NULL),
-                                NULL),
-            NULL),
-          NULL),
-
-      NULL,
-
       newcnode_bool(&A, JVST_CNODE_AND,
           newcnode_switch(&A, 1, SJP_NONE),
           newcnode_bool(&A, JVST_CNODE_OR,
@@ -921,30 +907,22 @@ void test_xlate_dependencies(void)
               SJP_NONE),
             NULL),
           NULL),
+
+      NULL
     },
 
-    { STOP },
+    { NULL },
   };
 
-  RUNTESTS(tests);
+  UNIMPLEMENTED(tests);
 }
 
-void test_xlate_anyof_allof_oneof_1(void)
+void test_ir_anyof_allof_oneof_1(void)
 {
   struct arena_info A = {0};
 
-  const struct cnode_test tests[] = {
+  const struct ir_test tests[] = {
     {
-      TRANSLATE,
-      newschema_p(&A, 0,
-          "anyOf", schema_set(&A, 
-            newschema_p(&A, JSON_VALUE_INTEGER, NULL),
-            newschema_p(&A, 0, "minimum", 2.0, NULL),
-            NULL),
-          NULL),
-
-      NULL,
-
       newcnode_bool(&A, JVST_CNODE_AND,
         newcnode_bool(&A, JVST_CNODE_OR,
           newcnode_switch(&A, 0,
@@ -959,19 +937,11 @@ void test_xlate_anyof_allof_oneof_1(void)
           NULL),
         newcnode_switch(&A, 1, SJP_NONE),
         NULL),
+
+      NULL
     },
 
     {
-      TRANSLATE,
-      newschema_p(&A, 0,
-          "allOf", schema_set(&A, 
-            newschema_p(&A, JSON_VALUE_INTEGER, NULL),
-            newschema_p(&A, 0, "minimum", 2.0, NULL),
-            NULL),
-          NULL),
-
-      NULL,
-
       newcnode_bool(&A, JVST_CNODE_AND,
         newcnode_bool(&A, JVST_CNODE_AND,
           newcnode_switch(&A, 0,
@@ -986,19 +956,11 @@ void test_xlate_anyof_allof_oneof_1(void)
           NULL),
         newcnode_switch(&A, 1, SJP_NONE),
         NULL),
+
+      NULL
     },
 
     {
-      TRANSLATE,
-      newschema_p(&A, 0,
-          "oneOf", schema_set(&A, 
-            newschema_p(&A, JSON_VALUE_INTEGER, NULL),
-            newschema_p(&A, 0, "minimum", 2.0, NULL),
-            NULL),
-          NULL),
-
-      NULL,
-
       newcnode_bool(&A, JVST_CNODE_AND,
         newcnode_bool(&A, JVST_CNODE_XOR,
           newcnode_switch(&A, 0,
@@ -1013,37 +975,23 @@ void test_xlate_anyof_allof_oneof_1(void)
           NULL),
         newcnode_switch(&A, 1, SJP_NONE),
         NULL),
+
+      NULL
     },
 
-    { STOP },
+    { NULL },
   };
 
-  RUNTESTS(tests);
+  UNIMPLEMENTED(tests);
 }
 
-void test_xlate_anyof_2(void)
+void test_ir_anyof_2(void)
 {
   struct arena_info A = {0};
-  struct ast_schema *schema = newschema_p(&A, 0,
-      "anyOf", schema_set(&A, 
-        newschema_p(&A, JSON_VALUE_OBJECT,
-          "properties", newprops(&A,
-            "foo", newschema_p(&A, JSON_VALUE_NUMBER, NULL),
-            "bar", newschema_p(&A, JSON_VALUE_STRING, NULL),
-            NULL),
-          NULL),
-        newschema_p(&A, JSON_VALUE_OBJECT,
-          "properties", newprops(&A,
-            "foo", newschema_p(&A, JSON_VALUE_STRING, NULL),
-            "bar", newschema_p(&A, JSON_VALUE_NUMBER, NULL),
-            NULL),
-          NULL),
-        NULL),
-      NULL);
 
-  const struct cnode_test tests[] = {
+  const struct ir_test tests[] = {
     {
-      TRANSLATE, schema, NULL, newcnode_bool(&A, JVST_CNODE_AND,
+      newcnode_bool(&A, JVST_CNODE_AND,
           newcnode_bool(&A, JVST_CNODE_OR,
             newcnode_switch(&A, 0,
               SJP_OBJECT_BEG, newcnode_bool(&A, JVST_CNODE_AND,
@@ -1071,79 +1019,43 @@ void test_xlate_anyof_2(void)
             NULL),
           newcnode_switch(&A, 1, SJP_NONE),
           NULL),
+      NULL
     },
-    { STOP },
+
+    { NULL },
   };
 
-  RUNTESTS(tests);
+  UNIMPLEMENTED(tests);
 }
 
-static void test_simplify_ands(void)
+static void test_ir_simplify_ands(void)
 {
   struct arena_info A = {0};
 
-  const struct cnode_test tests[] = {
+  const struct ir_test tests[] = {
     // handle AND with only one level...
     {
-      OPTIMIZE,
-
-      NULL,
-
-      newcnode_switch(&A, 1,
-          SJP_NUMBER, newcnode_bool(&A, JVST_CNODE_AND,
-                        newcnode_range(&A, JVST_CNODE_RANGE_MIN, 1.1, 0.0),
-                        newcnode_valid(),
-                        NULL),
-          SJP_NONE),
-
       newcnode_switch(&A, 1,
           SJP_NUMBER, newcnode_range(&A, JVST_CNODE_RANGE_MIN, 1.1, 0.0),
           SJP_NONE),
+
+      NULL
     },
 
     // handle nested ANDs
     {
-      OPTIMIZE,
-
-      NULL,
-
-      newcnode_switch(&A, 1,
-          SJP_NUMBER, newcnode_bool(&A, JVST_CNODE_AND,
-                        newcnode_bool(&A, JVST_CNODE_AND,
-                          newcnode_range(&A, JVST_CNODE_RANGE_MIN, 1.1, 0.0),
-                          newcnode_valid(),
-                          NULL),
-                        newcnode(&A,JVST_CNODE_NUM_INTEGER),
-                        NULL),
-          SJP_NONE),
-
       newcnode_switch(&A, 1,
           SJP_NUMBER, newcnode_bool(&A, JVST_CNODE_AND,
                         newcnode_range(&A, JVST_CNODE_RANGE_MIN, 1.1, 0.0),
                         newcnode(&A,JVST_CNODE_NUM_INTEGER),
                         NULL),
           SJP_NONE),
+
+      NULL
     },
 
     // handle more complex nested ANDs
     {
-      OPTIMIZE,
-      
-      NULL,
-
-      newcnode_switch(&A, 1,
-          SJP_NUMBER, newcnode_bool(&A, JVST_CNODE_AND,
-                        newcnode_bool(&A, JVST_CNODE_AND,
-                          newcnode_range(&A, JVST_CNODE_RANGE_MIN, 1.1, 0.0),
-                          newcnode_bool(&A, JVST_CNODE_AND,
-                            newcnode(&A,JVST_CNODE_NUM_INTEGER),
-                            newcnode_valid(),
-                            NULL),
-                          NULL),
-                        newcnode_range(&A, JVST_CNODE_RANGE_MAX, 0.0, 3.2),
-                        NULL),
-          SJP_NONE),
-
       newcnode_switch(&A, 1,
           SJP_NUMBER, newcnode_bool(&A, JVST_CNODE_AND,
                         newcnode_range(&A, JVST_CNODE_RANGE_MIN, 1.1, 0.0),
@@ -1151,52 +1063,21 @@ static void test_simplify_ands(void)
                         newcnode_range(&A, JVST_CNODE_RANGE_MAX, 0.0, 3.2),
                         NULL),
           SJP_NONE),
+
+      NULL
     },
 
-    { STOP },
+    { NULL },
   };
 
-  RUNTESTS(tests);
+  UNIMPLEMENTED(tests);
 }
 
-void test_simplify_ored_schema(void)
+void test_ir_simplify_ored_schema(void)
 {
   struct arena_info A = {0};
-  const struct cnode_test tests[] = {
+  const struct ir_test tests[] = {
     {
-      OPTIMIZE, NULL, 
-
-        // initial tree
-        newcnode_bool(&A, JVST_CNODE_AND,
-          newcnode_bool(&A, JVST_CNODE_OR,
-            newcnode_switch(&A, 0,
-              SJP_OBJECT_BEG, newcnode_bool(&A, JVST_CNODE_AND,
-                                newcnode_propset(&A, 
-                                  newcnode_prop_match(&A, RE_LITERAL, "foo",
-                                    newcnode_switch(&A, 0, SJP_NUMBER, newcnode_valid(), SJP_NONE)),
-                                  newcnode_prop_match(&A, RE_LITERAL, "bar",
-                                    newcnode_switch(&A, 0, SJP_STRING, newcnode_valid(), SJP_NONE)),
-                                  NULL),
-                                newcnode_valid(),
-                                NULL),
-              SJP_NONE),
-
-            newcnode_switch(&A, 0,
-              SJP_OBJECT_BEG, newcnode_bool(&A, JVST_CNODE_AND,
-                                newcnode_propset(&A,
-                                  newcnode_prop_match(&A, RE_LITERAL, "foo",
-                                    newcnode_switch(&A, 0, SJP_STRING, newcnode_valid(), SJP_NONE)),
-                                  newcnode_prop_match(&A, RE_LITERAL, "bar",
-                                    newcnode_switch(&A, 0, SJP_NUMBER, newcnode_valid(), SJP_NONE)),
-                                  NULL),
-                                newcnode_valid(),
-                                NULL),
-              SJP_NONE),
-            NULL),
-          newcnode_switch(&A, 1, SJP_NONE),
-          NULL),
-
-        // optimized
         newcnode_switch(&A, 0,
           SJP_OBJECT_BEG, newcnode_bool(&A, JVST_CNODE_OR,
                             newcnode_propset(&A, 
@@ -1213,55 +1094,11 @@ void test_simplify_ored_schema(void)
                               NULL),
                             NULL),
           SJP_NONE),
+
+        NULL
     },
 
     {
-      OPTIMIZE, 
-      // schema: {
-      //   "dependencies": {
-      //     "bar": {
-      //       "properties": {
-      //         "foo": {"type": "integer"},
-      //         "bar": {"type": "integer"}
-      //       }
-      //     }
-      //   }
-      // },
-      NULL,
-
-      // original cnode tree...
-      newcnode_bool(&A, JVST_CNODE_AND,
-          newcnode_switch(&A, 1, SJP_NONE),
-          newcnode_bool(&A, JVST_CNODE_OR,
-            newcnode_bool(&A, JVST_CNODE_AND,
-              newcnode_switch(&A, 0, 
-                SJP_OBJECT_BEG, newcnode_required(&A, stringset(&A, "bar", NULL)),
-                SJP_NONE),
-              newcnode_switch(&A, 1, 
-                SJP_OBJECT_BEG, newcnode_bool(&A, JVST_CNODE_AND,
-                                  newcnode_propset(&A,
-                                    newcnode_prop_match(&A, RE_LITERAL, "foo", 
-                                      newcnode_switch(&A, 0, 
-                                        SJP_NUMBER, newcnode(&A,JVST_CNODE_NUM_INTEGER),
-                                        SJP_NONE)),
-                                    newcnode_prop_match(&A, RE_LITERAL, "bar", 
-                                      newcnode_switch(&A, 0, 
-                                        SJP_NUMBER, newcnode(&A,JVST_CNODE_NUM_INTEGER),
-                                        SJP_NONE)),
-                                    NULL),
-                                  newcnode_valid(),
-                                  NULL),
-                SJP_NONE),
-              NULL),
-            newcnode_switch(&A, 1, 
-              SJP_OBJECT_BEG, newcnode_propset(&A,
-                                newcnode_prop_match(&A, RE_LITERAL, "bar", newcnode_invalid()),
-                                NULL),
-              SJP_NONE),
-            NULL),
-          NULL),
-
-      // simplified cnode tree
       newcnode_switch(&A, 1, 
           SJP_OBJECT_BEG, newcnode_bool(&A, JVST_CNODE_OR,
                             newcnode_bool(&A, JVST_CNODE_AND,
@@ -1282,16 +1119,13 @@ void test_simplify_ored_schema(void)
                               NULL),
                             NULL),
           SJP_NONE),
+
+      NULL
     },
-    { STOP },
+
+    { NULL },
   };
 
-  jvst_cnode_print(tests[0].expected);
-  fprintf(stderr, "\n\n");
-  jvst_cnode_print(tests[1].expected);
-  fprintf(stderr, "\n\n");
-
-  RUNTESTS(tests);
+  UNIMPLEMENTED(tests);
 }
-#endif /* 0 */
 

--- a/src/validate_constraints.c
+++ b/src/validate_constraints.c
@@ -315,13 +315,6 @@ jvst_cnode_free_tree(struct jvst_cnode *root)
 			jvst_cnode_free_tree(node->u.prop_match.constraint);
 			break;
 
-#if 0
-		case JVST_CNODE_OBJ_REQMASK:
-		case JVST_CNODE_OBJ_REQBIT:
-			// XXX - finalize the string set?
-			break;
-#endif /* 0 */
-
 		case JVST_CNODE_ARR_ITEM:
 		case JVST_CNODE_ARR_ADDITIONAL:
 			if (node->u.arr_item != NULL) {
@@ -597,16 +590,6 @@ and_or_xor:
 
 		sbuf_snprintf(buf, ")");
 		break;
-
-#if 0
-	case JVST_CNODE_OBJ_REQMASK:
-		sbuf_snprintf(buf, "REQMASK(nbits=%zu)", node->u.reqmask.nbits);
-		break;
-
-	case JVST_CNODE_OBJ_REQBIT:
-		sbuf_snprintf(buf, "REQBIT(bit=%zu)", node->u.reqbit.bit);
-		break;
-#endif /* 0 */
 
 	case JVST_CNODE_OBJ_REQUIRED:
 		{

--- a/src/validate_constraints.c
+++ b/src/validate_constraints.c
@@ -1365,7 +1365,8 @@ json_str_getc(void *p)
 	return ch;
 }
 
-static void merge_mcases(struct set *orig, struct fsm *dfa, struct fsm_state *comb)
+static void
+merge_mcases(struct set *orig, struct fsm *dfa, struct fsm_state *comb)
 {
 	struct jvst_cnode *mcase, *jxn, **jpp;
 	struct jvst_cnode_matchset **mspp;

--- a/src/validate_constraints.c
+++ b/src/validate_constraints.c
@@ -6,6 +6,15 @@
 #include <string.h>
 #include <limits.h>
 
+#include <adt/set.h>
+#include <fsm/bool.h>
+#include <fsm/fsm.h>
+#include <fsm/out.h>
+#include <fsm/options.h>
+#include <fsm/pred.h>
+#include <fsm/walk.h>
+#include <re/re.h>
+
 #include "xalloc.h"
 
 #include "jvst_macros.h"
@@ -110,6 +119,59 @@ cnode_strset_copy(struct ast_string_set *orig)
 	return head;
 }
 
+struct cnode_matchset_pool {
+	struct cnode_matchset_pool *next;
+	struct jvst_cnode_matchset items[JVST_CNODE_CHUNKSIZE];
+	unsigned char marks[MARKSIZE];
+};
+
+static struct {
+	struct cnode_matchset_pool *head;
+	size_t top;
+	struct jvst_cnode_matchset *freelist;
+} matchset_pool;
+
+static struct jvst_cnode_matchset *
+cnode_matchset_alloc(void)
+{
+	struct cnode_matchset_pool *pool;
+
+	if (matchset_pool.head == NULL) {
+		goto new_pool;
+	}
+
+	// first try bump allocation
+	if (matchset_pool.top < ARRAYLEN(matchset_pool.head->items)) {
+		return &matchset_pool.head->items[pool_item++];
+	}
+
+	// next try the free list
+	if (matchset_pool.freelist != NULL) {
+		struct jvst_cnode_matchset *ms;
+		ms = matchset_pool.freelist;
+		matchset_pool.freelist = ms->next;
+		return ms;
+	}
+
+new_pool:
+	// fall back to allocating a new pool
+	pool = xmalloc(sizeof *pool);
+	pool->next = matchset_pool.head;
+	matchset_pool.head = pool;
+	matchset_pool.top  = 1;
+	return &pool->items[0];
+}
+
+static struct jvst_cnode_matchset *
+cnode_matchset_new(struct ast_regexp match, struct jvst_cnode_matchset *next)
+{
+	struct jvst_cnode_matchset *ms;
+	ms = cnode_matchset_alloc();
+	ms->match = match;
+	ms->next = next;
+	return ms;
+}
+
 void
 json_string_finalize(struct json_string *s)
 {
@@ -176,6 +238,18 @@ cnode_new_switch(int allvalid)
 		node->u.sw[SJP_ARRAY_END]  = jvst_cnode_alloc(JVST_CNODE_INVALID);
 		node->u.sw[SJP_OBJECT_END] = jvst_cnode_alloc(JVST_CNODE_INVALID);
 	}
+
+	return node;
+}
+
+static struct jvst_cnode *
+cnode_new_mcase(struct jvst_cnode_matchset *ms, struct jvst_cnode *constraint)
+{
+	struct jvst_cnode *node;
+
+	node = jvst_cnode_alloc(JVST_CNODE_MATCH_CASE);
+	node->u.mcase.matchset = ms;
+	node->u.mcase.constraint = constraint;
 
 	return node;
 }
@@ -505,6 +579,99 @@ and_or_xor:
 		}
 		break;
 
+	case JVST_CNODE_MATCH_SWITCH:
+		{
+			struct jvst_cnode *c;
+
+			sbuf_snprintf(buf, "MATCH_SWITCH(\n");
+			if (node->u.mswitch.default_case != NULL) {
+				sbuf_indent(buf, indent+2);
+				sbuf_snprintf(buf, "DEFAULT[\n");
+
+				sbuf_indent(buf, indent+4);
+				jvst_cnode_dump_inner(node->u.mswitch.default_case, buf, indent + 4);
+				sbuf_snprintf(buf, "\n");
+
+				sbuf_indent(buf, indent+2);
+				if (node->u.mswitch.cases != NULL) {
+					sbuf_snprintf(buf, "],\n");
+				} else {
+					sbuf_snprintf(buf, "]\n");
+				}
+			}
+
+			for (c = node->u.mswitch.cases; c != NULL; c = c->next) {
+				assert(c->type == JVST_CNODE_MATCH_CASE);
+				sbuf_indent(buf, indent+2);
+				jvst_cnode_dump_inner(c, buf, indent+2);
+				if (c->next != NULL) {
+					sbuf_snprintf(buf, ",\n");
+				} else {
+					sbuf_snprintf(buf, "\n");
+				}
+			}
+			sbuf_indent(buf, indent);
+			sbuf_snprintf(buf, ")");
+		}
+		break;
+
+	case JVST_CNODE_MATCH_CASE:
+		{
+			struct jvst_cnode_matchset *ms;
+
+			sbuf_snprintf(buf, "MATCH_SWITCH(\n");
+			assert(node->u.mcase.matchset != NULL);
+
+			for (ms = node->u.mcase.matchset; ms != NULL; ms = ms->next) {
+				char str[256] = {0};
+				size_t n;
+
+				sbuf_indent(buf, indent+2);
+				sbuf_snprintf(buf, "P[");
+				switch (ms->match.dialect) {
+				case RE_LIKE:
+					sbuf_snprintf(buf, "LIKE");
+					break;
+
+				case RE_LITERAL:
+					sbuf_snprintf(buf, "LITERAL");
+					break;
+
+				case RE_GLOB:
+					sbuf_snprintf(buf, "GLOB");
+					break;
+
+				case RE_NATIVE:
+					sbuf_snprintf(buf, "NATIVE");
+					break;
+
+				default:
+					// avoid ??( trigraph by splitting
+					// "???(..." into "???" and "(..."
+					sbuf_snprintf(buf, "???" "(%d)", ms->match.dialect);
+					break;
+				}
+
+				n = ms->match.str.len;
+				if (n < sizeof str) {
+					memcpy(str, ms->match.str.s, n);
+				} else {
+					memcpy(str, ms->match.str.s, sizeof str - 4);
+					memcpy(str + sizeof str - 4, "...", 4);
+				}
+
+				sbuf_snprintf(buf, ", \"%s\"],\n", str);
+			}
+
+			sbuf_indent(buf, indent+2);
+			jvst_cnode_dump_inner(node->u.mcase.constraint, buf, indent+2);
+			sbuf_snprintf(buf, "\n");
+
+			sbuf_indent(buf, indent);
+			sbuf_snprintf(buf, ")");
+		}
+		break;
+
 	case JVST_CNODE_NOT:
 	case JVST_CNODE_STR_MATCH:
 	case JVST_CNODE_ARR_ITEM:
@@ -800,6 +967,67 @@ jvst_cnode_translate_ast(struct ast_schema *ast)
 }
 
 static struct jvst_cnode *
+cnode_deep_copy(struct jvst_cnode *node);
+
+static int
+mcase_copier(const struct fsm *dfa, const struct fsm_state *st)
+{
+	struct jvst_cnode *node, *ndup;
+
+	if (!fsm_isend(dfa, st)) {
+		return 1;
+	}
+
+	node = fsm_getopaque((struct fsm *)dfa, st);
+	assert(node->type == JVST_CNODE_MATCH_CASE);
+	assert(node->u.mcase.tmp == NULL);
+
+	ndup = cnode_deep_copy(node);
+	node->u.mcase.tmp = ndup;
+
+	fsm_setopaque((struct fsm *)dfa, (struct fsm_state *)st, ndup);
+
+	return 1;
+}
+
+static struct jvst_cnode *
+cnode_mswitch_copy(struct jvst_cnode *node)
+{
+	struct jvst_cnode *tree, *mcases, **mcpp;
+	struct fsm *dup_fsm;
+
+	tree = jvst_cnode_alloc(JVST_CNODE_MATCH_SWITCH);
+
+	// it would be lovely to copy this but there doesn't seem to be
+	// a way to get/set it on the fsm.
+	tree->u.mswitch.opts = node->u.mswitch.opts;
+
+	// duplicate FSM
+	//
+	// XXX - need to determine how we're keeping track of
+	// FSMs
+	dup_fsm = fsm_clone(node->u.mswitch.dfa);
+
+	tree->u.mswitch.dfa = dup_fsm;
+
+	// copy and collect all opaque states
+	fsm_all(dup_fsm, mcase_copier);
+
+	mcpp = &tree->u.mswitch.cases;
+	for (mcases = node->u.mswitch.cases; mcases != NULL; mcases = mcases->next) {
+		assert(mcases->u.mcase.tmp != NULL);
+		*mcpp = mcases->u.mcase.tmp;
+		mcases->u.mcase.tmp = NULL;
+		mcpp = &(*mcpp)->next;
+	}
+
+	assert(node->u.mswitch.default_case != NULL);
+	tree->u.mswitch.default_case = cnode_deep_copy(node->u.mswitch.default_case);
+
+	return tree;
+}
+
+static struct jvst_cnode *
 cnode_deep_copy(struct jvst_cnode *node)
 {
 	struct jvst_cnode *tree;
@@ -894,12 +1122,27 @@ cnode_deep_copy(struct jvst_cnode *node)
 		tree->u.arr_item = cnode_deep_copy(node->u.arr_item);
 		return tree;
 
-	default:
-		SHOULD_NOT_REACH();
+	case JVST_CNODE_MATCH_SWITCH:
+		return cnode_mswitch_copy(node);
+
+	case JVST_CNODE_MATCH_CASE:
+		{
+			struct jvst_cnode_matchset *mset, **mspp;
+
+			tree = jvst_cnode_alloc(JVST_CNODE_MATCH_CASE);
+			mspp = &tree->u.mcase.matchset;
+			for(mset = node->u.mcase.matchset; mset != NULL; mset = mset->next) {
+				*mspp = cnode_matchset_new(mset->match, NULL);
+				mspp = &(*mspp)->next;
+			}
+			tree->u.mcase.constraint = cnode_deep_copy(node->u.mcase.constraint);
+			return tree;
+		}
 	}
 
-	// now free the node
-	jvst_cnode_free(node);
+	// avoid default case in switch so the compiler can complain if
+	// we add new cnode types
+	SHOULD_NOT_REACH();
 }
 
 struct jvst_cnode *
@@ -1085,6 +1328,237 @@ cnode_optimize_andor(struct jvst_cnode *top)
 	return cnode_optimize_andor_switches(top);
 }
 
+struct json_str_iter {
+	struct json_string str;
+	size_t off;
+};
+
+static int
+json_str_getc(void *p)
+{
+	struct json_str_iter *iter = p;
+	unsigned char ch;
+
+	if (iter->off >= iter->str.len) {
+		return EOF;
+	}
+
+	ch = iter->str.s[iter->off++];
+	return ch;
+}
+
+static void merge_mcases(struct set *orig, struct fsm *dfa, struct fsm_state *comb)
+{
+	struct jvst_cnode *mcase, *jxn, **jpp;
+	struct jvst_cnode_matchset **mspp;
+	struct fsm_state *st;
+	struct set_iter it;
+	size_t nstates;
+
+	// first count states to make sure that we need to merge...
+	mcase = NULL;
+	nstates = 0;
+
+	for (st = set_first(orig, &it); st != NULL; st = set_next(&it)) {
+		struct jvst_cnode *c;
+
+		if (!fsm_isend(dfa, st)) {
+			continue;
+		}
+
+		c = fsm_getopaque(dfa, st);
+		assert(c != NULL);
+
+		// allow a fast path if nstates==1
+		if (mcase == NULL) {
+			mcase = c;
+		}
+
+		nstates++;
+	}
+
+	if (nstates == 0) {
+		return;
+	}
+
+	if (nstates == 1) {
+		assert(mcase != NULL);
+		fsm_setopaque(dfa, comb, mcase);
+		return;
+	}
+
+	// okay... need to combine things...
+	jxn = jvst_cnode_alloc(JVST_CNODE_AND);
+	jpp = &jxn->u.ctrl;
+	mcase = cnode_new_mcase(NULL, jxn);
+	mspp = &mcase->u.mcase.matchset;
+
+	for (st = set_first(orig, &it); st != NULL; st = set_next(&it)) {
+		struct jvst_cnode *c;
+		struct jvst_cnode_matchset *mset;
+
+		if (!fsm_isend(dfa, st)) {
+			continue;
+		}
+
+		c = fsm_getopaque(dfa, st);
+		assert(c != NULL);
+
+		assert(c->type == JVST_CNODE_MATCH_CASE);
+		assert(c->u.mcase.matchset != NULL);
+
+		// XXX - currently don't check for duplicates.
+		// Do we need to?
+		for (mset = c->u.mcase.matchset; mset != NULL; mset = mset->next) {
+			*mspp = cnode_matchset_new(mset->match, NULL);
+			mspp = &(*mspp)->next;
+		}
+
+		*jpp = cnode_deep_copy(c->u.mcase.constraint);
+		jpp = &(*jpp)->next;
+	}
+
+	fsm_setopaque(dfa, comb, mcase);
+}
+
+static struct jvst_cnode **mcase_collector_head;
+
+static int
+mcase_collector(const struct fsm *dfa, const struct fsm_state *st)
+{
+	struct jvst_cnode *node;
+
+	assert(mcase_collector_head != NULL);
+	assert(*mcase_collector_head == NULL);
+
+	if (!fsm_isend(dfa, st)) {
+		return 1;
+	}
+
+	node = fsm_getopaque((struct fsm *)dfa, st);
+	assert(node->type == JVST_CNODE_MATCH_CASE);
+	assert(node->next == NULL);
+
+	*mcase_collector_head = node;
+	mcase_collector_head = &node->next;
+
+	return 1;
+}
+
+static struct jvst_cnode *
+cnode_optimize_propset(struct jvst_cnode *top)
+{
+	struct jvst_cnode *pm, *mcases, *msw, **mcpp;
+	struct fsm_options *opts;
+	struct fsm *matches;
+
+	// FIXME: this is a leak...
+	opts = malloc(sizeof *opts);
+	*opts = (struct fsm_options) {
+		.tidy = false,
+		.anonymous_states = false,
+		.consolidate_edges = true,
+		.fragment = true,
+		.comments = true,
+		.case_ranges = true,
+
+		.io = FSM_IO_GETC,
+		.prefix = NULL,
+		.carryopaque = merge_mcases,
+	};
+
+	assert(top->type == JVST_CNODE_OBJ_PROP_SET);
+	assert(top->u.prop_set != NULL);
+
+	// step 1: iterate over PROP_MATCH nodes and optimize each
+	// constraint individually
+	// 
+	// step 2: construct a FSM from all PROP_MATCH nodes.
+	//
+	// This involves:
+	//
+	//  a. create an FSM for each PROP_MATCH node
+	//  b. create a MATCH_CASE for each PROP_MATCH node
+	//  c. Set the MATCH_CASE as the opaque value for all end states
+	//     in the FSM
+	//  d. Union the FSM with the previous FSMs.
+	matches = NULL;
+	for (pm = top->u.prop_set; pm != NULL; pm=pm->next) {
+		struct jvst_cnode *cons, *mcase;
+		struct jvst_cnode_matchset *mset;
+		struct fsm *pat;
+		struct json_str_iter siter;
+		struct re_err err = { 0 };
+
+		cons = jvst_cnode_optimize(pm->u.prop_match.constraint);
+		mset = cnode_matchset_new(pm->u.prop_match.match, NULL);
+		mcase = cnode_new_mcase(mset, cons);
+
+		siter.str = pm->u.prop_match.match.str;
+		siter.off = 0;
+
+		pat = re_comp(
+			pm->u.prop_match.match.dialect,
+			json_str_getc,
+			&siter,
+			opts,
+			(enum re_flags)0,
+			&err);
+
+		// errors should be checked in parsing
+		assert(pat != NULL);
+
+		fsm_setendopaque(pat, mcase);
+
+		if (matches == NULL) {
+			matches = pat;
+		} else {
+			matches = fsm_union(matches, pat);
+
+			// XXX - we can't handle failure states right
+			// now...
+			assert(matches != NULL);
+		}
+	}
+
+	// step 3: convert the FSM from an NFA to a DFA.
+	//
+	// This may involve merging MATCH_CASE nodes.  The rules are
+	// fairly simple: combine pattern sets, combine constraints with
+	// an AND condition.
+	//
+	// NB: combining requires copying because different end states
+	// may still have the original MATCH_CASE node.
+
+	if (!fsm_determinise(matches)) {
+		perror("cannot determinise fsm");
+		abort();
+	}
+
+	// step 4: collect all MATCH_CASE nodes from the DFA by
+	// iterating over the DFA end states.  All MATCH_CASE nodes must
+	// be placed into a linked list.
+	mcases = NULL;
+	mcase_collector_head = &mcases; // XXX - ugly global variable
+
+	fsm_all(matches, mcase_collector);
+
+	// step 5: build the MATCH_SWITCH container to hold the cases
+	// and the DFA.  The default case should be VALID.
+	msw = jvst_cnode_alloc(JVST_CNODE_MATCH_SWITCH);
+	msw->u.mswitch.dfa = matches;
+	msw->u.mswitch.opts = opts;
+	msw->u.mswitch.cases = mcases;
+	msw->u.mswitch.default_case = jvst_cnode_alloc(JVST_CNODE_VALID);
+
+	// step 6: optimize the constraint of each MATCH_CASE node
+	for (; mcases != NULL; mcases = mcases->next) {
+		mcases->u.mcase.constraint = jvst_cnode_optimize(mcases->u.mcase.constraint);
+	}
+
+	return msw;
+}
+
 struct jvst_cnode *
 jvst_cnode_optimize(struct jvst_cnode *tree)
 {
@@ -1122,6 +1596,8 @@ jvst_cnode_optimize(struct jvst_cnode *tree)
 		return tree;
 
 	case JVST_CNODE_OBJ_PROP_SET:
+		return cnode_optimize_propset(tree);
+
 	case JVST_CNODE_NUM_RANGE:
 	case JVST_CNODE_COUNT_RANGE:
 	case JVST_CNODE_STR_MATCH:
@@ -1129,12 +1605,15 @@ jvst_cnode_optimize(struct jvst_cnode *tree)
 	case JVST_CNODE_OBJ_REQUIRED:
 	case JVST_CNODE_ARR_ITEM:
 	case JVST_CNODE_ARR_ADDITIONAL:
+	case JVST_CNODE_MATCH_SWITCH:
+	case JVST_CNODE_MATCH_CASE:
 		// TODO: basic optimization for these nodes
 		return tree;
-
-	default:
-		SHOULD_NOT_REACH();
 	}
+
+	// avoid default case in switch so the compiler can complain if
+	// we add new cnode types
+	SHOULD_NOT_REACH();
 }
 
 /* vim: set tabstop=8 shiftwidth=8 noexpandtab: */

--- a/src/validate_constraints.h
+++ b/src/validate_constraints.h
@@ -139,7 +139,7 @@ struct jvst_cnode {
 			struct jvst_cnode *constraint;
 
 			// temp storage used in duplication
-			struct jvst_cnode *tmp;
+			void *tmp;
 		} mcase;
 
 		/* Nodes used for simplifying required properties */

--- a/src/validate_constraints.h
+++ b/src/validate_constraints.h
@@ -58,11 +58,28 @@ enum jvst_cnode_type {
 
 	JVST_CNODE_OBJ_PROP_SET,
 	JVST_CNODE_OBJ_PROP_MATCH,
+
 	JVST_CNODE_OBJ_REQUIRED,
+	// JVST_CNODE_OBJ_REQMASK,
+	// JVST_CNODE_OBJ_REQBIT,
 
 	JVST_CNODE_ARR_ITEM,
 	JVST_CNODE_ARR_ADDITIONAL,
 	JVST_CNODE_ARR_UNIQUE,
+
+	// Nodes used in optimization/simplification to reduce the
+	// complexity of matching.
+	//
+	// After a DFA is created, MATCH_SWITCH holds the overall
+	// matching, while MATCH_CASE holds the unique matching
+	// endstates
+	JVST_CNODE_MATCH_SWITCH,
+	JVST_CNODE_MATCH_CASE,
+};
+
+struct jvst_cnode_matchset {
+	struct jvst_cnode_matchset *next;
+	struct ast_regexp match;
 };
 
 struct jvst_cnode {
@@ -95,7 +112,7 @@ struct jvst_cnode {
 			double max;
 		} num_range;
 
-		/* object required property */
+		/* support for required properties */
 		struct ast_string_set *required;
 
 		struct jvst_cnode *prop_set;
@@ -108,6 +125,34 @@ struct jvst_cnode {
 
 		// for array item and additional_item constraints
 		struct jvst_cnode *arr_item;
+
+		/* Nodes used for simplifying property matching */
+		struct {
+			struct jvst_cnode *default_case;
+			struct jvst_cnode *cases;
+			struct fsm *dfa;
+			struct fsm_options *opts;
+		} mswitch;
+
+		struct {
+			struct jvst_cnode_matchset *matchset;
+			struct jvst_cnode *constraint;
+
+			// temp storage used in duplication
+			struct jvst_cnode *tmp;
+		} mcase;
+
+		/* Nodes used for simplifying required properties */
+		/*
+		struct {
+			size_t nbits;
+		} reqmask;
+
+		struct {
+			size_t bit;
+		} reqbit;
+		*/
+
 	} u;
 };
 

--- a/src/validate_ir.c
+++ b/src/validate_ir.c
@@ -1339,28 +1339,4 @@ jvst_ir_translate(struct jvst_cnode *ctree)
 	return frame;
 }
 
-#if 0
-	switch (ctree->type) {
-	case JVST_CNODE_INVALID: 
-	case JVST_CNODE_VALID:       
-	case JVST_CNODE_AND: 
-	case JVST_CNODE_OR:  
-	case JVST_CNODE_XOR: 
-	case JVST_CNODE_NOT:
-	case JVST_CNODE_SWITCH:
-	case JVST_CNODE_COUNT_RANGE:
-	case JVST_CNODE_STR_MATCH:
-	case JVST_CNODE_NUM_RANGE:
-	case JVST_CNODE_NUM_INTEGER:
-	case JVST_CNODE_OBJ_PROP_SET:
-	case JVST_CNODE_OBJ_REQUIRED:
-
-	case JVST_CNODE_ARR_ITEM:
-	case JVST_CNODE_ARR_ADDITIONAL:
-	case JVST_CNODE_ARR_UNIQUE:
-
-	case JVST_CNODE_OBJ_PROP_MATCH:
-#endif /* 0 */
-
-
 /* vim: set tabstop=8 shiftwidth=8 noexpandtab: */

--- a/src/validate_ir.c
+++ b/src/validate_ir.c
@@ -14,6 +14,7 @@
 #include <fsm/out.h>
 #include <fsm/options.h>
 #include <fsm/pred.h>
+#include <fsm/walk.h>
 #include <re/re.h>
 
 #include "validate_sbuf.h"
@@ -673,6 +674,10 @@ jvst_ir_dump_expr(struct sbuf *buf, struct jvst_ir_expr *expr, int indent)
 
 }
 
+// definition in validate_constraints.c
+void
+jvst_cnode_matchset_dump(struct jvst_cnode_matchset *ms, struct sbuf *buf, int indent);
+
 void
 jvst_ir_dump_inner(struct sbuf *buf, struct jvst_ir_stmt *ir, int indent)
 {
@@ -779,8 +784,15 @@ jvst_ir_dump_inner(struct sbuf *buf, struct jvst_ir_stmt *ir, int indent)
 			}
 
 			for (cases = ir->u.match.cases; cases != NULL; cases = cases->next) {
+				struct jvst_cnode_matchset *mset;
+
 				sbuf_indent(buf, indent+2);
 				sbuf_snprintf(buf, "CASE(%zu,\n", cases->which);
+
+				for (mset=cases->matchset; mset != NULL; mset = mset->next) {
+					jvst_cnode_matchset_dump(mset, buf, indent+4);
+					sbuf_snprintf(buf, ",\n");
+				}
 
 				jvst_ir_dump_inner(buf, cases->stmt, indent+4);
 				sbuf_snprintf(buf, "\n");
@@ -1002,26 +1014,32 @@ static void merge_constraints(struct set *orig, struct fsm *dfa, struct fsm_stat
 	}
 }
 
-struct json_str_iter {
-	struct json_string str;
-	size_t off;
-};
+#define UNASSIGNED_MATCH  (~(size_t)0)
 
 static int
-json_str_getc(void *p)
+mcase_builder(const struct fsm *dfa, const struct fsm_state *st)
 {
-	struct json_str_iter *iter = p;
-	unsigned char ch;
+	struct jvst_cnode *node;
+	struct jvst_ir_mcase *mcase;
+	struct jvst_ir_stmt *stmt;
 
-	if (iter->off >= iter->str.len) {
-		return EOF;
+	if (!fsm_isend(dfa, st)) {
+		return 1;
 	}
 
-	ch = iter->str.s[iter->off++];
-	return ch;
-}
+	node = fsm_getopaque((struct fsm *)dfa, st);
+	assert(node->type == JVST_CNODE_MATCH_CASE);
+	assert(node->u.mcase.tmp == NULL);
 
-#define UNASSIGNED_MATCH  (~(size_t)0)
+	stmt = jvst_ir_translate(node->u.mcase.constraint);
+	mcase = ir_mcase_new(UNASSIGNED_MATCH, stmt);
+	mcase->matchset = node->u.mcase.matchset;
+
+	node->u.mcase.tmp = mcase;
+	fsm_setopaque((struct fsm *)dfa, (struct fsm_state *)st, mcase);
+
+	return 1;
+}
 
 static struct jvst_ir_stmt *
 ir_translate_object(struct jvst_cnode *top, struct jvst_ir_stmt *frame)
@@ -1034,24 +1052,10 @@ ir_translate_object(struct jvst_cnode *top, struct jvst_ir_stmt *frame)
 	struct jvst_ir_mcase **mcpp;
 	size_t nreqs;
 
-	// FIXME: this is a leak...
-	opts = malloc(sizeof *opts);
-	*opts = (struct fsm_options) {
-		.tidy = false,
-		.anonymous_states = false,
-		.consolidate_edges = true,
-		.fragment = true,
-		.comments = true,
-		.case_ranges = true,
-
-		.io = FSM_IO_GETC,
-		.prefix = NULL,
-		.carryopaque = merge_constraints,
-	};
-
 	stmt = ir_stmt_new(JVST_IR_STMT_SEQ);
 	spp = &stmt->u.stmt_list;
 	pre_loop = spp;
+
 	oloop = ir_stmt_loop(frame,"L_OBJ");
 	*spp = oloop;
 	post_loop = &oloop->next;
@@ -1086,52 +1090,59 @@ ir_translate_object(struct jvst_cnode *top, struct jvst_ir_stmt *frame)
 	switch (top->type) {
 	case JVST_CNODE_VALID:
 	case JVST_CNODE_INVALID:
+		// VALID/INVALID should have been picked up in the
+		// various cases...
 		fprintf(stderr, "top node should not be VALID or INVALID\n");
 		abort();
 		break;
 
 	case JVST_CNODE_OBJ_PROP_SET:
-		for (pmatch = top->u.prop_set; pmatch != NULL; pmatch = pmatch->next) {
-			struct fsm *pat;
-			struct re_err err = { 0 };
-			struct jvst_ir_stmt *stmts;
-			struct jvst_ir_mcase *mcase;
-			struct json_str_iter siter;
+		fprintf(stderr, "simplified cnode trees should not have PROP_SET nodes\n");
+		abort();
+		break;
 
-			stmts = jvst_ir_translate(pmatch->u.prop_match.constraint);
-			mcase = ir_mcase_new(UNASSIGNED_MATCH, stmts);
-			*mcpp = mcase;
-			mcpp = &(*mcpp)->next;
+	case JVST_CNODE_MATCH_SWITCH:
+		{
+			size_t which;
+			struct jvst_cnode *caselist;
+			struct jvst_ir_stmt *frame, **spp;
 
-			siter.str = pmatch->u.prop_match.match.str;
-			siter.off = 0;
+			// duplicate DFA.
+			matcher = fsm_clone(top->u.mswitch.dfa);
+			match->u.match.dfa = matcher;
 
-			pat = re_comp(
-				pmatch->u.prop_match.match.dialect,
-				json_str_getc,
-				&siter,
-				opts,
-				(enum re_flags)0,
-				&err);
+			// replace MATCH_CASE opaque entries in copy with jvst_ir_mcase nodes
+			fsm_all(matcher, mcase_builder);
 
-			// errors should be checked in parsing
-			assert(pat != NULL);
+			// assemble jvst_ir_mcase nodes into list for an MATCH_SWITCH node and number the cases
+			which = 0;
+			for (caselist = top->u.mswitch.cases; caselist != NULL; caselist = caselist->next) {
+				struct jvst_ir_mcase *mc;
+				assert(caselist->type == JVST_CNODE_MATCH_CASE);
+				assert(caselist->u.mcase.tmp != NULL);
 
-			fsm_setendopaque(pat, mcase);
+				mc = caselist->u.mcase.tmp;
+				assert(mc->next == NULL);
 
-			fprintf(stderr, "matcher is %p\n", (void *)matcher);
-			if (matcher == NULL) {
-				matcher = pat;
-			} else {
-				// XXX - any error handling required?
-				matcher = fsm_union(matcher, pat);
-
-				// we can't handle failure states right
-				// now...
-				assert(matcher != NULL);
+				mc->which = ++which;
+				*mcpp = mc;
+				mcpp = &mc->next;
 			}
-		}
 
+			// 4. translate the default case
+			//
+			// FIXME: either default_case is always VALID or
+			// we need to do something more sophisticated
+			// here.
+			frame = ir_stmt_frame();
+			match->u.match.default_case = frame;
+			spp = &frame->u.frame.stmts;
+			*spp = ir_stmt_new(JVST_IR_STMT_TOKEN);
+			spp = &(*spp)->next;
+			*spp = ir_stmt_new(JVST_IR_STMT_VALID);
+
+			// match->u.match.default_case = jvst_ir_translate(top->u.mswitch.default_case);
+		}
 		break;
 
 	case JVST_CNODE_OBJ_REQUIRED:

--- a/src/validate_ir.h
+++ b/src/validate_ir.h
@@ -101,6 +101,7 @@ struct jvst_ir_label;
 struct jvst_ir_mcase {
 	struct jvst_ir_mcase *next;
 	size_t which;
+	struct jvst_cnode_matchset *matchset;
 	struct jvst_ir_stmt *stmt;
 };
 

--- a/src/validate_testing.c
+++ b/src/validate_testing.c
@@ -12,6 +12,19 @@
 
 int ntest;
 int nfail;
+int nskipped;
+
+int
+report_tests(void)
+{
+	if (nskipped > 0) {
+		printf("%d tests, %d failures, %d skipped\n", ntest, nfail, nskipped);
+	} else {
+		printf("%d tests, %d failures\n", ntest, nfail);
+	}
+
+	return ((nfail == 0) && (ntest > 0)) ?  EXIT_SUCCESS : EXIT_FAILURE;
+}
 
 enum { NUM_TEST_THINGS = 1024 };
 

--- a/src/validate_testing.c
+++ b/src/validate_testing.c
@@ -806,7 +806,7 @@ newir_match(struct arena_info *A, size_t ind, ...)
 }
 
 struct jvst_ir_mcase *
-newir_case(struct arena_info *A, size_t ind, struct jvst_ir_stmt *frame)
+newir_case(struct arena_info *A, size_t ind, struct jvst_cnode_matchset *mset, struct jvst_ir_stmt *frame)
 {
 	size_t i, max;
 	struct jvst_ir_mcase *c;
@@ -821,6 +821,7 @@ newir_case(struct arena_info *A, size_t ind, struct jvst_ir_stmt *frame)
 	c  = &ar_ir_mcases[i];
 	memset(c , 0, sizeof *c );
 	c->which = ind;
+	c->matchset = mset;
 	c->stmt = frame;
 
 	return c;

--- a/src/validate_testing.h
+++ b/src/validate_testing.h
@@ -18,7 +18,10 @@ struct arena_info {
 	size_t nstr;
 	size_t npnames;
 	size_t nset;
+
+	/* cnode related */
 	size_t ncnode;
+	size_t nmatchsets;
 
         /* IR related */
         size_t nstmt;
@@ -84,6 +87,18 @@ newcnode_invalid(void);
 struct jvst_cnode *
 newcnode_required(struct arena_info *A, struct ast_string_set *sset);
 
+struct jvst_cnode *
+newcnode_mswitch(struct arena_info *A, struct jvst_cnode *dft, ...);
+
+struct jvst_cnode *
+newcnode_mcase(struct arena_info *A, struct jvst_cnode_matchset *mset,
+	struct jvst_cnode *constraint);
+
+struct jvst_cnode_matchset *
+newmatchset(struct arena_info *A, ...);
+
+
+/* IR-related */
 struct jvst_ir_stmt *
 newir_stmt(struct arena_info *A, enum jvst_ir_stmt_type type);
 

--- a/src/validate_testing.h
+++ b/src/validate_testing.h
@@ -11,6 +11,7 @@
 
 extern int ntest;
 extern int nfail;
+extern int nskipped;
 
 struct arena_info {
 	size_t nschema;
@@ -150,15 +151,8 @@ newir_num(struct arena_info *A, double num);
 const char *
 jvst_ret2name(int ret);
 
-static inline int
-report_tests(void)
-{
-	printf("%d tests, %d failures\n", ntest, nfail);
-	if (nfail == 0 && ntest > 0) {
-		return EXIT_SUCCESS;
-	}
-	return EXIT_FAILURE;
-}
+int
+report_tests(void);
 
 #endif /* TESTING_H */
 

--- a/src/validate_testing.h
+++ b/src/validate_testing.h
@@ -131,7 +131,7 @@ struct jvst_ir_stmt *
 newir_match(struct arena_info *A, size_t ind, ...);
 
 struct jvst_ir_mcase *
-newir_case(struct arena_info *A, size_t ind, struct jvst_ir_stmt *frame);
+newir_case(struct arena_info *A, size_t ind, struct jvst_cnode_matchset *mset, struct jvst_ir_stmt *frame);
 
 struct jvst_ir_expr *
 newir_istok(struct arena_info *A, enum SJP_EVENT tt);


### PR DESCRIPTION
Moved AST construction from IR to cnode level to take advantage of simplifications and optimizations at the cnode level.