### PR TITLE
More transformations to simplify / canonify cnodes

### DIFF
--- a/src/test_constraints.c
+++ b/src/test_constraints.c
@@ -986,6 +986,66 @@ static void test_simplify_ands(void)
   RUNTESTS(tests);
 }
 
+void test_simplify_propsets(void)
+{
+  struct arena_info A = {0};
+  const struct cnode_test tests[] = {
+    {
+      SIMPLIFY, NULL, 
+
+      // initial tree
+      newcnode_switch(&A, 0,
+        SJP_OBJECT_BEG, newcnode_bool(&A, JVST_CNODE_AND,
+                          newcnode_propset(&A, 
+                            newcnode_prop_match(&A, RE_NATIVE, "foo",
+                              newcnode_switch(&A, 0, SJP_NUMBER, newcnode_valid(), SJP_NONE)),
+
+                            newcnode_prop_match(&A, RE_LITERAL, "bar",
+                              newcnode_switch(&A, 0, SJP_STRING, newcnode_valid(), SJP_NONE)),
+                            NULL),
+
+                          newcnode_propset(&A, 
+                            newcnode_prop_match(&A, RE_NATIVE, "this",
+                              newcnode_switch(&A, 0,
+                                SJP_TRUE, newcnode_valid(),
+                                SJP_FALSE, newcnode_valid(),
+                                SJP_NONE)),
+
+                            newcnode_prop_match(&A, RE_LITERAL, "bar",
+                              newcnode_switch(&A, 0, SJP_NUMBER, newcnode_valid(), SJP_NONE)),
+                            NULL),
+                          NULL
+                        ),
+        SJP_NONE),
+
+      // optimized
+      newcnode_switch(&A, 0,
+        SJP_OBJECT_BEG, newcnode_propset(&A, 
+                          newcnode_prop_match(&A, RE_NATIVE, "foo",
+                            newcnode_switch(&A, 0, SJP_NUMBER, newcnode_valid(), SJP_NONE)),
+
+                          newcnode_prop_match(&A, RE_LITERAL, "bar",
+                            newcnode_switch(&A, 0, SJP_STRING, newcnode_valid(), SJP_NONE)),
+
+                          newcnode_prop_match(&A, RE_NATIVE, "this",
+                            newcnode_switch(&A, 0,
+                              SJP_TRUE, newcnode_valid(),
+                              SJP_FALSE, newcnode_valid(),
+                              SJP_NONE)),
+
+                          newcnode_prop_match(&A, RE_LITERAL, "bar",
+                            newcnode_switch(&A, 0, SJP_NUMBER, newcnode_valid(), SJP_NONE)),
+                          NULL),
+        SJP_NONE),
+
+    },
+
+    { STOP },
+  };
+
+  RUNTESTS(tests);
+}
+
 void test_simplify_ored_schema(void)
 {
   struct arena_info A = {0};
@@ -1288,7 +1348,6 @@ void test_canonify_ored_schema(void)
   RUNTESTS(tests);
 }
 
-
 void test_canonify_propsets(void)
 {
   struct arena_info A = {0};
@@ -1366,6 +1425,7 @@ int main(void)
 
   test_simplify_ands();
   test_simplify_ored_schema();
+  test_simplify_propsets();
 
   test_canonify_ored_schema();
   test_canonify_propsets();

--- a/src/test_constraints.c
+++ b/src/test_constraints.c
@@ -10,8 +10,9 @@
 enum TEST_OP {
   STOP = 0,
   TRANSLATE,
-  OPTIMIZE,
-  BOTH,
+  SIMPLIFY,
+  CANONIFY,
+  ALL,
 
   // add specific optimization stages...
   //
@@ -44,15 +45,21 @@ static int run_test(const char *fname, const struct cnode_test *t)
       result = jvst_cnode_translate_ast(t->ast);
       break;
 
-    case BOTH:
-      assert(t->ast != NULL);
-      // result = jvst_cnode_from_ast(t->ast);
-      fprintf(stderr, "BOTH pass not implemented\n");
-      abort();
+    case SIMPLIFY:
+      result = jvst_cnode_simplify(t->cnode);
       break;
 
-    case OPTIMIZE:
-      result = jvst_cnode_optimize(t->cnode);
+    case CANONIFY:
+      assert(t->ast != NULL);
+      // result = jvst_cnode_from_ast(t->ast);
+      fprintf(stderr, "CANONIFY pass not implemented\n");
+      abort();
+
+    case ALL:
+      assert(t->ast != NULL);
+      // result = jvst_cnode_from_ast(t->ast);
+      fprintf(stderr, "ALL passes not implemented\n");
+      abort();
       break;
   }
 
@@ -901,7 +908,7 @@ static void test_simplify_ands(void)
   const struct cnode_test tests[] = {
     // handle AND with only one level...
     {
-      OPTIMIZE,
+      SIMPLIFY,
 
       NULL,
 
@@ -919,7 +926,7 @@ static void test_simplify_ands(void)
 
     // handle nested ANDs
     {
-      OPTIMIZE,
+      SIMPLIFY,
 
       NULL,
 
@@ -943,7 +950,7 @@ static void test_simplify_ands(void)
 
     // handle more complex nested ANDs
     {
-      OPTIMIZE,
+      SIMPLIFY,
       
       NULL,
 
@@ -980,7 +987,7 @@ void test_simplify_ored_schema(void)
   struct arena_info A = {0};
   const struct cnode_test tests[] = {
     {
-      OPTIMIZE, NULL, 
+      SIMPLIFY, NULL, 
 
         // initial tree
         newcnode_bool(&A, JVST_CNODE_AND,
@@ -1055,7 +1062,7 @@ void test_simplify_ored_schema(void)
     },
 
     {
-      OPTIMIZE, 
+      SIMPLIFY, 
       // schema: {
       //   "dependencies": {
       //     "bar": {
@@ -1157,7 +1164,7 @@ void test_simplify_propsets(void)
   struct arena_info A = {0};
   const struct cnode_test tests[] = {
     {
-      OPTIMIZE, NULL, 
+      SIMPLIFY, NULL, 
 
         // initial tree
         newcnode_switch(&A, 0,

--- a/src/test_constraints.c
+++ b/src/test_constraints.c
@@ -1046,6 +1046,36 @@ void test_simplify_propsets(void)
   RUNTESTS(tests);
 }
 
+void test_simplify_required(void)
+{
+  struct arena_info A = {0};
+
+  // initial schema is not reduced (additional constraints are ANDed
+  // together).  Reduction will occur on a later pass.
+  const struct cnode_test tests[] = {
+    {
+      SIMPLIFY, NULL,
+
+      newcnode_bool(&A,JVST_CNODE_AND,
+        newcnode_switch(&A, 1,
+          SJP_OBJECT_BEG, newcnode_required(&A, stringset(&A, "foo", NULL)),
+          SJP_NONE),
+        newcnode_switch(&A, 1,
+          SJP_OBJECT_BEG, newcnode_required(&A, stringset(&A, "bar", NULL)),
+          SJP_NONE),
+        NULL),
+
+      newcnode_switch(&A, 1,
+        SJP_OBJECT_BEG, newcnode_required(&A, stringset(&A, "foo", "bar", NULL)),
+        SJP_NONE),
+
+    },
+    { STOP },
+  };
+
+  RUNTESTS(tests);
+}
+
 void test_simplify_ored_schema(void)
 {
   struct arena_info A = {0};
@@ -1426,6 +1456,7 @@ int main(void)
   test_simplify_ands();
   test_simplify_ored_schema();
   test_simplify_propsets();
+  test_simplify_required();
 
   test_canonify_ored_schema();
   test_canonify_propsets();

--- a/src/test_ir.c
+++ b/src/test_ir.c
@@ -786,12 +786,12 @@ void test_ir_minproperties_2(void)
                         )
                       ),
 
-                      // match "bar"
+                      // match "foo"
                       newir_case(&A, 1,
-                        newmatchset(&A, RE_LITERAL,  "bar", -1),
+                        newmatchset(&A, RE_LITERAL,  "foo", -1),
                         newir_frame(&A,
                           newir_stmt(&A, JVST_IR_STMT_TOKEN),
-                          newir_if(&A, newir_istok(&A, SJP_STRING),
+                          newir_if(&A, newir_istok(&A, SJP_NUMBER),
                             newir_stmt(&A, JVST_IR_STMT_VALID),
                             newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token")
                           ),
@@ -799,12 +799,12 @@ void test_ir_minproperties_2(void)
                         )
                       ),
 
-                      // match "foo"
+                      // match "bar"
                       newir_case(&A, 2,
-                        newmatchset(&A, RE_LITERAL,  "foo", -1),
+                        newmatchset(&A, RE_LITERAL,  "bar", -1),
                         newir_frame(&A,
                           newir_stmt(&A, JVST_IR_STMT_TOKEN),
-                          newir_if(&A, newir_istok(&A, SJP_NUMBER),
+                          newir_if(&A, newir_istok(&A, SJP_STRING),
                             newir_stmt(&A, JVST_IR_STMT_VALID),
                             newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token")
                           ),

--- a/src/test_ir.c
+++ b/src/test_ir.c
@@ -18,14 +18,15 @@ static int ir_trees_equal(const char *fname, struct jvst_ir_stmt *n1, struct jvs
 
 static int run_test(const char *fname, const struct ir_test *t)
 {
-  struct jvst_cnode *opt;
+  struct jvst_cnode *simplified, *canonified;
   struct jvst_ir_stmt *result;
 
   assert(t->ctree != NULL);
   assert(t->ir != NULL);
 
-  opt = jvst_cnode_optimize(t->ctree);
-  result = jvst_ir_translate(opt);
+  simplified = jvst_cnode_simplify(t->ctree);
+  canonified = jvst_cnode_canonify(simplified);
+  result = jvst_ir_translate(canonified);
 
   return ir_trees_equal(fname, result, t->ir);
 }
@@ -785,12 +786,12 @@ void test_ir_minproperties_2(void)
                         )
                       ),
 
-                      // match "foo"
+                      // match "bar"
                       newir_case(&A, 1,
-                        newmatchset(&A, RE_LITERAL,  "foo", -1),
+                        newmatchset(&A, RE_LITERAL,  "bar", -1),
                         newir_frame(&A,
                           newir_stmt(&A, JVST_IR_STMT_TOKEN),
-                          newir_if(&A, newir_istok(&A, SJP_NUMBER),
+                          newir_if(&A, newir_istok(&A, SJP_STRING),
                             newir_stmt(&A, JVST_IR_STMT_VALID),
                             newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token")
                           ),
@@ -798,12 +799,12 @@ void test_ir_minproperties_2(void)
                         )
                       ),
 
-                      // match "bar"
+                      // match "foo"
                       newir_case(&A, 2,
-                        newmatchset(&A, RE_LITERAL,  "bar", -1),
+                        newmatchset(&A, RE_LITERAL,  "foo", -1),
                         newir_frame(&A,
                           newir_stmt(&A, JVST_IR_STMT_TOKEN),
-                          newir_if(&A, newir_istok(&A, SJP_STRING),
+                          newir_if(&A, newir_istok(&A, SJP_NUMBER),
                             newir_stmt(&A, JVST_IR_STMT_VALID),
                             newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token")
                           ),

--- a/src/test_ir.c
+++ b/src/test_ir.c
@@ -172,7 +172,7 @@ static void runtests(const char *testname, const struct ir_test tests[])
     ntest++;
 
     if (!run_test(testname, &tests[i])) {
-      printf("%s_%d: failed\n", testname, i+1);
+      printf("%s[%d]: failed\n", testname, i+1);
       nfail++;
     }
   }
@@ -851,13 +851,130 @@ void test_ir_minproperties_2(void)
   RUNTESTS(tests);
 }
 
+void test_ir_required(void)
+{
+  struct arena_info A = {0};
+
+  // initial schema is not reduced (additional constraints are ANDed
+  // together).  Reduction will occur on a later pass.
+  const struct ir_test tests[] = {
+    {
+      // schema:
+      // {
+      //   "properties" : {
+      //     "foo" : { "type" : "number" },
+      //     "foo" : { "type" : "string" }
+      //   },
+      //   "required" : [ "foo" ]
+      // }
+      newcnode_switch(&A, 1,
+        SJP_OBJECT_BEG, newcnode_bool(&A,JVST_CNODE_AND,
+                          newcnode_required(&A, stringset(&A, "foo", NULL)),
+                          newcnode_propset(&A,
+                            newcnode_prop_match(&A, RE_LITERAL, "foo",
+                              newcnode_switch(&A, 0,
+                                SJP_NUMBER, newcnode_valid(),
+                                SJP_NONE)),
+                            newcnode_prop_match(&A, RE_LITERAL, "bar",
+                              newcnode_switch(&A, 0,
+                                SJP_STRING, newcnode_valid(),
+                                SJP_NONE)),
+                            NULL),
+                          NULL),
+        SJP_NONE),
+
+      newir_frame(&A,
+          newir_bitvec(&A, 0, "reqmask", 1),
+          newir_matcher(&A, 0, "dfa"),
+          newir_stmt(&A, JVST_IR_STMT_TOKEN),
+          newir_if(&A, newir_istok(&A, SJP_OBJECT_BEG),
+            newir_seq(&A,
+              newir_loop(&A, "L_OBJ", 0,
+                newir_stmt(&A, JVST_IR_STMT_TOKEN),
+                newir_if(&A, newir_istok(&A, SJP_OBJECT_END),
+                  newir_break(&A, "L_OBJ", 0),
+                  newir_seq(&A,                                 // unnecessary SEQ should be removed in the future
+                    newir_match(&A, 0,
+                      // no match
+                      newir_case(&A, 0, 
+                        NULL,
+                        newir_frame(&A,
+                          newir_stmt(&A, JVST_IR_STMT_TOKEN),
+                          newir_stmt(&A, JVST_IR_STMT_VALID),
+                          NULL
+                        )
+                      ),
+
+                      // match "bar"
+                      newir_case(&A, 1,
+                        newmatchset(&A, RE_LITERAL,  "bar", -1),
+                        newir_frame(&A,
+                          newir_stmt(&A, JVST_IR_STMT_TOKEN),
+                          newir_if(&A, newir_istok(&A, SJP_STRING),
+                            newir_stmt(&A, JVST_IR_STMT_VALID),
+                            newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token")
+                          ),
+                          NULL
+                        )
+                      ),
+
+                      // match "foo"
+                      newir_case(&A, 2,
+                        newmatchset(&A, RE_LITERAL,  "foo", RE_LITERAL, "foo", -1),
+                        newir_seq(&A,
+                          newir_frame(&A,
+                            newir_stmt(&A, JVST_IR_STMT_TOKEN),
+                            newir_if(&A, newir_istok(&A, SJP_NUMBER),
+                              newir_stmt(&A, JVST_IR_STMT_VALID),
+                              newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token")
+                            ),
+                            NULL
+                          ),
+                          newir_bitop(&A, JVST_IR_STMT_BSET, 0, "reqmask", 0),
+                          NULL
+                        )
+                      ),
+
+                      NULL
+                    ),
+                    NULL
+                  )
+                ),
+                NULL
+              ),
+              newir_if(&A,
+                  newir_btestall(&A, 0, "reqmask"),
+                  newir_stmt(&A, JVST_IR_STMT_VALID),
+                  newir_invalid(&A, JVST_INVALID_MISSING_REQUIRED_PROPERTIES,
+                    "missing required properties")
+              ),
+              NULL
+            ),
+
+            newir_if(&A, newir_istok(&A, SJP_OBJECT_END),
+              newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token"),
+              newir_if(&A, newir_istok(&A, SJP_ARRAY_END),
+                newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token"),
+                newir_stmt(&A, JVST_IR_STMT_VALID)
+              )
+            )
+          ),
+          NULL
+      )
+    },
+
+    { NULL },
+  };
+
+  RUNTESTS(tests);
+}
+
 /* incomplete tests... placeholders for conversion from cnode tests */
 static void test_ir_minproperties_3(void);
 static void test_ir_maxproperties_1(void);
 static void test_ir_maxproperties_2(void);
 static void test_ir_minmax_properties_2(void);
 
-static void test_ir_required(void);
 static void test_ir_dependencies(void);
 
 static void test_ir_anyof_allof_oneof_1(void);
@@ -879,13 +996,14 @@ int main(void)
   test_ir_minmax_properties_1();
   test_ir_minproperties_2();
 
+  test_ir_required();
+
   /* incomplete tests... placeholders for conversion from cnode tests */
   test_ir_minproperties_3();
   test_ir_maxproperties_1();
   test_ir_maxproperties_2();
   test_ir_minmax_properties_2();
 
-  test_ir_required();
   test_ir_dependencies();
 
   test_ir_anyof_allof_oneof_1();
@@ -1057,41 +1175,6 @@ void test_ir_minmax_properties_2(void)
         SJP_NONE),
 
       NULL
-    },
-
-    { NULL },
-  };
-
-  UNIMPLEMENTED(tests);
-}
-
-void test_ir_required(void)
-{
-  struct arena_info A = {0};
-  struct ast_schema *schema = newschema_p(&A, 0,
-      "properties", newprops(&A,
-        "foo", empty_schema(),
-        "bar", empty_schema(),
-        NULL),
-      "required", stringset(&A, "foo", NULL),
-      NULL);
-
-  // initial schema is not reduced (additional constraints are ANDed
-  // together).  Reduction will occur on a later pass.
-  const struct ir_test tests[] = {
-    {
-      newcnode_switch(&A, 1,
-        SJP_OBJECT_BEG, newcnode_bool(&A,JVST_CNODE_AND,
-                          newcnode_required(&A, stringset(&A, "foo", NULL)),
-                          newcnode_bool(&A,JVST_CNODE_AND,
-                            newcnode_propset(&A,
-                              newcnode_prop_match(&A, RE_LITERAL, "foo", newcnode_switch(&A, 1, SJP_NONE)),
-                              newcnode_prop_match(&A, RE_LITERAL, "bar", newcnode_switch(&A, 1, SJP_NONE)),
-                              NULL),
-                            newcnode_valid(),
-                            NULL),
-                          NULL),
-        SJP_NONE),
     },
 
     { NULL },

--- a/src/validate_constraints.c
+++ b/src/validate_constraints.c
@@ -372,11 +372,18 @@ jvst_cnode_type_name(enum jvst_cnode_type type)
 		return "ARR_ADDITIONAL";
 	case JVST_CNODE_ARR_UNIQUE:
 		return "ARR_UNIQUE";
-
-	default:
-		fprintf(stderr, "unknown cnode type %d\n", type);
-		abort();
+	case JVST_CNODE_OBJ_REQMASK:
+		return "OBJ_REQMASK";
+	case JVST_CNODE_OBJ_REQBIT:
+		return "OBJ_REQBIT";
+	case JVST_CNODE_MATCH_SWITCH:
+		return "MATCH_SWITCH";
+	case JVST_CNODE_MATCH_CASE:
+		return "MATCH_CASE";
 	}
+
+	fprintf(stderr, "unknown cnode type %d\n", type);
+	abort();
 }
 
 void

--- a/src/validate_constraints.h
+++ b/src/validate_constraints.h
@@ -60,16 +60,19 @@ enum jvst_cnode_type {
 	JVST_CNODE_OBJ_PROP_MATCH,
 
 	JVST_CNODE_OBJ_REQUIRED,
-	// JVST_CNODE_OBJ_REQMASK,
-	// JVST_CNODE_OBJ_REQBIT,
 
 	JVST_CNODE_ARR_ITEM,
 	JVST_CNODE_ARR_ADDITIONAL,
 	JVST_CNODE_ARR_UNIQUE,
 
-	// Nodes used in optimization/simplification to reduce the
-	// complexity of matching.
-	//
+	// The following node types are only present after
+	// canonification.
+
+	// During first pass at canonification, transform REQUIRED nodes
+	// into REQMASK/REQBIT nodes
+	JVST_CNODE_OBJ_REQMASK,
+	JVST_CNODE_OBJ_REQBIT,
+
 	// After a DFA is created, MATCH_SWITCH holds the overall
 	// matching, while MATCH_CASE holds the unique matching
 	// endstates
@@ -143,15 +146,22 @@ struct jvst_cnode {
 		} mcase;
 
 		/* Nodes used for simplifying required properties */
-		/*
 		struct {
 			size_t nbits;
 		} reqmask;
 
 		struct {
+			// XXX - do we need to refer to parent to keep
+			//       the bit numbering consistent?
+			//
+			//       consider: two ANDed REQUIRED nodes.
+			//       we *could* require them to be merged
+			//       before transforming them into
+			//       reqmask/reqbit nodes.  This would
+			//       require splitting the canonify stage
+			//       into two parts.
 			size_t bit;
 		} reqbit;
-		*/
 
 	} u;
 };

--- a/src/validate_constraints.h
+++ b/src/validate_constraints.h
@@ -168,8 +168,8 @@ jvst_cnode_free_tree(struct jvst_cnode *n);
 const char *
 jvst_cnode_type_name(enum jvst_cnode_type type);
 
-// Translates the AST into a contraint tree and optimizes the constraint
-// tree
+// Translates the AST into a contraint tree, first simplifying and
+// canonifying the constraint tree
 struct jvst_cnode *
 jvst_cnode_from_ast(struct ast_schema *ast);
 
@@ -178,9 +178,13 @@ jvst_cnode_from_ast(struct ast_schema *ast);
 struct jvst_cnode *
 jvst_cnode_translate_ast(struct ast_schema *ast);
 
-// Optimize the cnode tree.  Returns a new tree.
+// Simplfies the cnode tree.  Returns a new tree.
 struct jvst_cnode *
-jvst_cnode_optimize(struct jvst_cnode *tree);
+jvst_cnode_simplify(struct jvst_cnode *tree);
+
+// Canonifies the cnode tree.  Returns a new tree.
+struct jvst_cnode *
+jvst_cnode_canonify(struct jvst_cnode *tree);
 
 // Writes a textual represetnation of the cnode into the buffer,
 // returns 0 if the representation fit, non-zero otherwise

--- a/src/validate_ir.h
+++ b/src/validate_ir.h
@@ -60,6 +60,7 @@ enum jvst_ir_expr_type {
 
 	JVST_IR_EXPR_COUNT, 		// counter value.  args: index; result: size
 	JVST_IR_EXPR_BTEST,		// tests if a bit is set.  args: (bvec<index>,bit<index>); result: bool
+	JVST_IR_EXPR_BTESTALL,		// true if all bits in the bit vector are set.  args(bvec<index>), result: bool
 
 	JVST_IR_EXPR_ISTOK,		// tests curernt token type.  args: tok_type; result: bool
 
@@ -92,6 +93,7 @@ enum jvst_invalid_code {
 	JVST_INVALID_NUMBER           = 0x0003,
 	JVST_INVALID_TOO_FEW_PROPS    = 0x0004,
 	JVST_INVALID_TOO_MANY_PROPS   = 0x0005,
+	JVST_INVALID_MISSING_REQUIRED_PROPERTIES = 0x0006,
 };
 
 const char *
@@ -110,10 +112,12 @@ struct jvst_ir_mcase {
 struct jvst_ir_frame {
 	struct jvst_ir_stmt *counters;
 	struct jvst_ir_stmt *matchers;
+	struct jvst_ir_stmt *bitvecs;
 	struct jvst_ir_stmt *stmts;
 	size_t nloops;
 	size_t nmatchers;
 	size_t ncounters;
+	size_t nbitvecs;
 };
 
 struct jvst_ir_stmt {
@@ -170,10 +174,18 @@ struct jvst_ir_stmt {
 		} matcher;
 
 		struct {
-			struct jvst_ir_label *label;
-			struct jvst_ir_frame *frame;
+			struct jvst_ir_stmt *frame;
+			const char *label;
 			size_t ind;
-		} bitvector;
+			size_t nbits;
+		} bitvec;
+
+		struct {
+			struct jvst_ir_stmt *frame;
+			const char *label;
+			size_t ind;
+			size_t bit;
+		} bitop;
 
 		size_t index;
 

--- a/src/validate_testing.c
+++ b/src/validate_testing.c
@@ -524,6 +524,28 @@ newcnode_required(struct arena_info *A, struct ast_string_set *sset)
 }
 
 struct jvst_cnode *
+newcnode_reqmask(struct arena_info *A, size_t nbits)
+{
+	struct jvst_cnode *node;
+
+	node = newcnode(A, JVST_CNODE_OBJ_REQMASK);
+	node->u.reqmask.nbits = nbits;
+
+	return node;
+}
+
+struct jvst_cnode *
+newcnode_reqbit(struct arena_info *A, size_t bit)
+{
+	struct jvst_cnode *node;
+
+	node = newcnode(A, JVST_CNODE_OBJ_REQBIT);
+	node->u.reqbit.bit = bit;
+
+	return node;
+}
+
+struct jvst_cnode *
 newcnode_mswitch(struct arena_info *A, struct jvst_cnode *dft, ...)
 {
 	struct jvst_cnode *node, **cpp;

--- a/src/validate_testing.h
+++ b/src/validate_testing.h
@@ -89,6 +89,12 @@ struct jvst_cnode *
 newcnode_required(struct arena_info *A, struct ast_string_set *sset);
 
 struct jvst_cnode *
+newcnode_reqmask(struct arena_info *A, size_t nbits);
+
+struct jvst_cnode *
+newcnode_reqbit(struct arena_info *A, size_t bit);
+
+struct jvst_cnode *
 newcnode_mswitch(struct arena_info *A, struct jvst_cnode *dft, ...);
 
 struct jvst_cnode *

--- a/src/validate_testing.h
+++ b/src/validate_testing.h
@@ -138,10 +138,16 @@ struct jvst_ir_stmt *
 newir_matcher(struct arena_info *A, size_t ind, const char *name);
 
 struct jvst_ir_stmt *
+newir_bitvec(struct arena_info *A, size_t ind, const char *label, size_t nbits);
+
+struct jvst_ir_stmt *
 newir_match(struct arena_info *A, size_t ind, ...);
 
 struct jvst_ir_stmt *
 newir_incr(struct arena_info *A, size_t ind, const char *label);
+
+struct jvst_ir_stmt *
+newir_bitop(struct arena_info *A, enum jvst_ir_stmt_type op, size_t ind, const char *label, size_t bit);
 
 struct jvst_ir_mcase *
 newir_case(struct arena_info *A, size_t ind, struct jvst_cnode_matchset *mset, struct jvst_ir_stmt *frame);
@@ -165,6 +171,9 @@ newir_size(struct arena_info *A, size_t sz);
 
 struct jvst_ir_expr *
 newir_count(struct arena_info *A, size_t ind, const char *label);
+
+struct jvst_ir_expr *
+newir_btestall(struct arena_info *A, size_t ind, const char *label);
 
 const char *
 jvst_ret2name(int ret);


### PR DESCRIPTION
Split cnode "optimization" into two major phases that work together.  The first simplifies the cnode tree.  The second converts cnodes into simpler forms and builds the DFAs.

Most of this is a precursor to translating required constraints to the IR.  Basically, REQUIRED nodes are converted into a subtree of AND(REQMASK(nbits), PROPSET(...)), where the PROPSET has one PROP_MATCH node for each required property.  The constraint on the PROP_MATCH node is  REQBIT(b) node that sets a unique bit in the reqmask.

PROPSETs are then combined, DFAs are built, and all PROPSET subtrees are converted into MATCH_SWITCH subtrees.

Once the REQMASK/REQBIT nodes are in the right places, it's straightforward to translate them into the IR.