### PR TITLE
Sorts MATCH_CASE nodes to keep the output ordering deterministic

### DIFF
--- a/src/validate_constraints.c
+++ b/src/validate_constraints.c
@@ -1677,8 +1677,6 @@ mcase_collector(const struct fsm *dfa, const struct fsm_state *st)
 	return 1;
 }
 
-static bool opt_sort_mcases = true;
-
 static int matchset_cmp(const void *p0, const void *p1)
 {
 	const struct jvst_cnode_matchset *const *ms0, *const *ms1;
@@ -1907,7 +1905,11 @@ cnode_canonify_propset(struct jvst_cnode *top)
 
 	fsm_all(matches, mcase_collector);
 
-	// step 4: sort the MATCH_CASE nodes
+	// step 4: sort the MATCH_CASE nodes.
+	//
+	// This keeps the IR output deterministic (useful for testing,
+	// possibly other places?).  Currently this could be elided (or
+	// put behind an optional flag) if necessary.
 	sort_mcases(&mcases);
 
 	// step 5: build the MATCH_SWITCH container to hold the cases

--- a/src/validate_ir.c
+++ b/src/validate_ir.c
@@ -549,7 +549,8 @@ jvst_ir_stmt_type_name(enum jvst_ir_stmt_type type)
 		return "MATCH";    	
 
 	default:
-		fprintf(stderr, "unknown IR statement type %d\n", type);
+		fprintf(stderr, "%s:%d unknown IR statement type %d in %s\n",
+			__FILE__, __LINE__, type, __func__);
 		abort();
 	}
 }
@@ -668,8 +669,6 @@ void dump_stmt_list(struct sbuf *buf, enum jvst_ir_stmt_type type, struct jvst_i
 void
 jvst_ir_dump_expr(struct sbuf *buf, struct jvst_ir_expr *expr, int indent)
 {
-	(void)indent;
-
 	sbuf_indent(buf, indent);
 	switch (expr->type) {
 	case JVST_IR_EXPR_NONE:
@@ -1204,8 +1203,6 @@ struct ir_object_builder {
 static struct jvst_ir_stmt *
 obj_mcase_translate_inner(struct jvst_cnode *ctree, struct ir_object_builder *builder)
 {
-	(void)builder;
-
 	switch (ctree->type) {
 	case JVST_CNODE_OBJ_REQBIT:
 		{
@@ -2180,6 +2177,21 @@ jvst_ir_translate(struct jvst_cnode *ctree)
 		;
 
 	return frame;
+}
+
+void
+jvst_ir_print(struct jvst_ir_stmt *stmt)
+{
+	size_t i;
+	// FIXME: gross hack
+	char buf[65536] = {0}; // 64K
+
+	jvst_ir_dump(stmt, buf, sizeof buf);
+	for (i=0; i < 72; i++) {
+		fprintf(stderr, "-");
+	}
+	fprintf(stderr, "\n");
+	fprintf(stderr, "%s\n", buf);
 }
 
 /* vim: set tabstop=8 shiftwidth=8 noexpandtab: */

--- a/src/validate_ir.h
+++ b/src/validate_ir.h
@@ -277,6 +277,10 @@ jvst_ir_expr_type_name(enum jvst_ir_expr_type type);
 const char *
 jvst_ir_stmt_type_name(enum jvst_ir_stmt_type type);
 
+// for debugging, prints node to stderr
+void
+jvst_ir_print(struct jvst_ir_stmt *node);
+
 #endif /* JVST_VALIDATE_IR_H */
 
 /* vim: set tabstop=8 shiftwidth=8 noexpandtab: */

--- a/tests/test_constraints.c
+++ b/tests/test_constraints.c
@@ -1519,13 +1519,6 @@ void test_canonify_ored_schema(void)
                                 newcnode_valid(),
 
                                 newcnode_mcase(&A,
-                                  newmatchset(&A, RE_LITERAL, "foo", -1),
-                                    newcnode_switch(&A, 0, 
-                                      SJP_NUMBER, newcnode(&A,JVST_CNODE_NUM_INTEGER),
-                                      SJP_NONE)
-                                ),
-
-                                newcnode_mcase(&A,
                                   newmatchset(&A, RE_LITERAL, "bar", RE_LITERAL, "bar", -1),
                                   newcnode_bool(&A, JVST_CNODE_AND,
                                     newcnode_switch(&A, 0, 
@@ -1533,6 +1526,13 @@ void test_canonify_ored_schema(void)
                                       SJP_NONE),
                                     newcnode_reqbit(&A, 0),
                                     NULL)
+                                ),
+
+                                newcnode_mcase(&A,
+                                  newmatchset(&A, RE_LITERAL, "foo", -1),
+                                    newcnode_switch(&A, 0, 
+                                      SJP_NUMBER, newcnode(&A,JVST_CNODE_NUM_INTEGER),
+                                      SJP_NONE)
                                 ),
 
                                 NULL
@@ -1589,17 +1589,17 @@ void test_canonify_propsets(void)
 
                             newcnode_mcase(&A,
                               newmatchset(&A,
-                                RE_NATIVE,  "ba.",
-                                -1),
-                              newcnode_switch(&A, 0, SJP_NUMBER, newcnode_valid(), SJP_NONE)
-                            ),
-
-                            newcnode_mcase(&A,
-                              newmatchset(&A,
                                 RE_LITERAL, "bar",
                                 RE_NATIVE,  "ba.",
                                 -1),
                               newcnode_switch(&A, 0, SJP_NONE)
+                            ),
+
+                            newcnode_mcase(&A,
+                              newmatchset(&A,
+                                RE_NATIVE,  "ba.",
+                                -1),
+                              newcnode_switch(&A, 0, SJP_NUMBER, newcnode_valid(), SJP_NONE)
                             ),
 
                             NULL),

--- a/tests/test_ir.c
+++ b/tests/test_ir.c
@@ -10,7 +10,7 @@
 #include "validate_ir.h"
 
 #ifndef PRINT_IR
-#  define PRINT_IR 1
+#  define PRINT_IR 0
 #endif /* PRINT_IR */
 
 struct ir_test {
@@ -447,8 +447,18 @@ void test_ir_properties(void)
                         newir_stmt(&A, JVST_IR_STMT_CONSUME)
                       ),
 
-                      // match /ba./
+                      // match "bar" AND "ba."
                       newir_case(&A, 1,
+                        newmatchset(&A, RE_LITERAL, "bar", RE_NATIVE,  "ba.", -1),
+                        newir_frame(&A,
+                          newir_stmt(&A, JVST_IR_STMT_TOKEN),   // XXX - is this necessary?
+                          newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token"),
+                          NULL
+                        )
+                      ),
+
+                      // match /ba./
+                      newir_case(&A, 2,
                         newmatchset(&A, RE_NATIVE,  "ba.", -1),
                         newir_frame(&A,
                           newir_stmt(&A, JVST_IR_STMT_TOKEN),
@@ -456,16 +466,6 @@ void test_ir_properties(void)
                             newir_stmt(&A, JVST_IR_STMT_VALID),
                             newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token")
                           ),
-                          NULL
-                        )
-                      ),
-
-                      // match "bar" AND "ba."
-                      newir_case(&A, 2,
-                        newmatchset(&A, RE_LITERAL, "bar", RE_NATIVE,  "ba.", -1),
-                        newir_frame(&A,
-                          newir_stmt(&A, JVST_IR_STMT_TOKEN),   // XXX - is this necessary?
-                          newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token"),
                           NULL
                         )
                       ),
@@ -772,12 +772,12 @@ void test_ir_minproperties_2(void)
                         newir_stmt(&A, JVST_IR_STMT_CONSUME)
                       ),
 
-                      // match "foo"
+                      // match "bar"
                       newir_case(&A, 1,
-                        newmatchset(&A, RE_LITERAL,  "foo", -1),
+                        newmatchset(&A, RE_LITERAL,  "bar", -1),
                         newir_frame(&A,
                           newir_stmt(&A, JVST_IR_STMT_TOKEN),
-                          newir_if(&A, newir_istok(&A, SJP_NUMBER),
+                          newir_if(&A, newir_istok(&A, SJP_STRING),
                             newir_stmt(&A, JVST_IR_STMT_VALID),
                             newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token")
                           ),
@@ -785,12 +785,12 @@ void test_ir_minproperties_2(void)
                         )
                       ),
 
-                      // match "bar"
+                      // match "foo"
                       newir_case(&A, 2,
-                        newmatchset(&A, RE_LITERAL,  "bar", -1),
+                        newmatchset(&A, RE_LITERAL,  "foo", -1),
                         newir_frame(&A,
                           newir_stmt(&A, JVST_IR_STMT_TOKEN),
-                          newir_if(&A, newir_istok(&A, SJP_STRING),
+                          newir_if(&A, newir_istok(&A, SJP_NUMBER),
                             newir_stmt(&A, JVST_IR_STMT_VALID),
                             newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token")
                           ),
@@ -1025,21 +1025,21 @@ void test_ir_dependencies(void)
                                   newir_stmt(&A, JVST_IR_STMT_CONSUME)
                                 ),
 
-                                // match "foo"
+                                // match "bar"
                                 newir_case(&A, 1,
-                                  newmatchset(&A, RE_LITERAL,  "foo", -1),
+                                  newmatchset(&A, RE_LITERAL,  "bar", -1),
                                   newir_seq(&A,
-                                    newir_bitop(&A, JVST_IR_STMT_BSET, 0, "reqmask", 1),
+                                    newir_bitop(&A, JVST_IR_STMT_BSET, 0, "reqmask", 0),
                                     newir_stmt(&A, JVST_IR_STMT_CONSUME),
                                     NULL
                                   )
                                 ),
 
-                                // match "bar"
+                                // match "foo"
                                 newir_case(&A, 2,
-                                  newmatchset(&A, RE_LITERAL,  "bar", -1),
+                                  newmatchset(&A, RE_LITERAL,  "foo", -1),
                                   newir_seq(&A,
-                                    newir_bitop(&A, JVST_IR_STMT_BSET, 0, "reqmask", 0),
+                                    newir_bitop(&A, JVST_IR_STMT_BSET, 0, "reqmask", 1),
                                     newir_stmt(&A, JVST_IR_STMT_CONSUME),
                                     NULL
                                   )

--- a/tests/test_ir.c
+++ b/tests/test_ir.c
@@ -9,6 +9,10 @@
 
 #include "validate_ir.h"
 
+#ifndef PRINT_IR
+#  define PRINT_IR 1
+#endif /* PRINT_IR */
+
 struct ir_test {
   struct jvst_cnode *ctree;
   struct jvst_ir_stmt *ir;
@@ -27,6 +31,10 @@ static int run_test(const char *fname, const struct ir_test *t)
   simplified = jvst_cnode_simplify(t->ctree);
   canonified = jvst_cnode_canonify(simplified);
   result = jvst_ir_translate(canonified);
+
+#if PRINT_IR
+  jvst_ir_print(result);
+#endif /* PRINT_IR */
 
   return ir_trees_equal(fname, result, t->ir);
 }
@@ -212,7 +220,7 @@ static void test_ir_type_constraints(void)
   };
 
   const struct ir_test tests[] = {
-    { 
+    {
       newcnode_switch(&A, 0, SJP_NUMBER, newcnode_valid(), SJP_NONE),
 
       newir_frame(&A,
@@ -237,7 +245,8 @@ static void test_ir_type_constraints(void)
       )
     },
 
-    { newcnode_switch(&A, 0,
+    {
+      newcnode_switch(&A, 0,
         SJP_OBJECT_BEG, newcnode_valid(),
         SJP_STRING, newcnode_valid(),
         SJP_NONE),

--- a/tests/test_ir.c
+++ b/tests/test_ir.c
@@ -193,6 +193,7 @@ static void test_ir_empty_schema(void)
   const struct ir_test tests[] = {
     {
       newcnode_switch(&A, 1, SJP_NONE),
+
       newir_frame(&A,
           newir_stmt(&A, JVST_IR_STMT_TOKEN),
           newir_if(&A, newir_istok(&A, SJP_OBJECT_END),

--- a/tests/test_ir.c
+++ b/tests/test_ir.c
@@ -367,11 +367,7 @@ void test_ir_properties(void)
                       // no match
                       newir_case(&A, 0, 
                         NULL,
-                        newir_frame(&A,
-                          newir_stmt(&A, JVST_IR_STMT_TOKEN),
-                          newir_stmt(&A, JVST_IR_STMT_VALID),
-                          NULL
-                        )
+                        newir_stmt(&A, JVST_IR_STMT_CONSUME)
                       ),
 
                       // match "bar"
@@ -447,11 +443,7 @@ void test_ir_properties(void)
                       // no match
                       newir_case(&A, 0, 
                         NULL,
-                        newir_frame(&A,
-                          newir_stmt(&A, JVST_IR_STMT_TOKEN),
-                          newir_stmt(&A, JVST_IR_STMT_VALID),
-                          NULL
-                        )
+                        newir_stmt(&A, JVST_IR_STMT_CONSUME)
                       ),
 
                       // match /ba./
@@ -541,11 +533,7 @@ void test_ir_minmax_properties_1(void)
                       // no match
                       newir_case(&A, 0, 
                         NULL,
-                        newir_frame(&A,
-                          newir_stmt(&A, JVST_IR_STMT_TOKEN),
-                          newir_stmt(&A, JVST_IR_STMT_VALID),
-                          NULL
-                        )
+                        newir_stmt(&A, JVST_IR_STMT_CONSUME)
                       ),
 
                       NULL
@@ -627,11 +615,7 @@ void test_ir_minmax_properties_1(void)
                       // no match
                       newir_case(&A, 0, 
                         NULL,
-                        newir_frame(&A,
-                          newir_stmt(&A, JVST_IR_STMT_TOKEN),
-                          newir_stmt(&A, JVST_IR_STMT_VALID),
-                          NULL
-                        )
+                        newir_stmt(&A, JVST_IR_STMT_CONSUME)
                       ),
 
                       NULL
@@ -700,11 +684,7 @@ void test_ir_minmax_properties_1(void)
                       // no match
                       newir_case(&A, 0, 
                         NULL,
-                        newir_frame(&A,
-                          newir_stmt(&A, JVST_IR_STMT_TOKEN),
-                          newir_stmt(&A, JVST_IR_STMT_VALID),
-                          NULL
-                        )
+                        newir_stmt(&A, JVST_IR_STMT_CONSUME)
                       ),
 
                       NULL
@@ -788,11 +768,7 @@ void test_ir_minproperties_2(void)
                       // no match
                       newir_case(&A, 0, 
                         NULL,
-                        newir_frame(&A,
-                          newir_stmt(&A, JVST_IR_STMT_TOKEN),
-                          newir_stmt(&A, JVST_IR_STMT_VALID),
-                          NULL
-                        )
+                        newir_stmt(&A, JVST_IR_STMT_CONSUME)
                       ),
 
                       // match "foo"
@@ -907,11 +883,7 @@ void test_ir_required(void)
                       // no match
                       newir_case(&A, 0, 
                         NULL,
-                        newir_frame(&A,
-                          newir_stmt(&A, JVST_IR_STMT_TOKEN),
-                          newir_stmt(&A, JVST_IR_STMT_VALID),
-                          NULL
-                        )
+                        newir_stmt(&A, JVST_IR_STMT_CONSUME)
                       ),
 
                       // match "bar"
@@ -1014,11 +986,7 @@ void test_ir_dependencies(void)
                                 // no match
                                 newir_case(&A, 0, 
                                   NULL,
-                                  newir_frame(&A,
-                                    newir_stmt(&A, JVST_IR_STMT_TOKEN),
-                                    newir_stmt(&A, JVST_IR_STMT_VALID),
-                                    NULL
-                                  )
+                                  newir_stmt(&A, JVST_IR_STMT_CONSUME)
                                 ),
 
                                 // match "bar"
@@ -1053,23 +1021,27 @@ void test_ir_dependencies(void)
                                 // no match
                                 newir_case(&A, 0, 
                                   NULL,
-                                  newir_frame(&A,
-                                    newir_stmt(&A, JVST_IR_STMT_TOKEN),
-                                    newir_stmt(&A, JVST_IR_STMT_VALID),
-                                    NULL
-                                  )
+                                  newir_stmt(&A, JVST_IR_STMT_CONSUME)
                                 ),
 
                                 // match "foo"
                                 newir_case(&A, 1,
                                   newmatchset(&A, RE_LITERAL,  "foo", -1),
-                                  newir_bitop(&A, JVST_IR_STMT_BSET, 0, "reqmask", 1)
+                                  newir_seq(&A,
+                                    newir_bitop(&A, JVST_IR_STMT_BSET, 0, "reqmask", 1),
+                                    newir_stmt(&A, JVST_IR_STMT_CONSUME),
+                                    NULL
+                                  )
                                 ),
 
                                 // match "bar"
                                 newir_case(&A, 2,
                                   newmatchset(&A, RE_LITERAL,  "bar", -1),
-                                  newir_bitop(&A, JVST_IR_STMT_BSET, 0, "reqmask", 0)
+                                  newir_seq(&A,
+                                    newir_bitop(&A, JVST_IR_STMT_BSET, 0, "reqmask", 0),
+                                    newir_stmt(&A, JVST_IR_STMT_CONSUME),
+                                    NULL
+                                  )
                                 ),
 
                                 NULL
@@ -1138,11 +1110,7 @@ void test_ir_dependencies(void)
                                 // no match
                                 newir_case(&A, 0, 
                                   NULL,
-                                  newir_frame(&A,
-                                    newir_stmt(&A, JVST_IR_STMT_TOKEN),
-                                    newir_stmt(&A, JVST_IR_STMT_VALID),
-                                    NULL
-                                  )
+                                  newir_stmt(&A, JVST_IR_STMT_CONSUME)
                                 ),
 
                                 // match "bar"
@@ -1177,29 +1145,37 @@ void test_ir_dependencies(void)
                                 // no match
                                 newir_case(&A, 0, 
                                   NULL,
-                                  newir_frame(&A,
-                                    newir_stmt(&A, JVST_IR_STMT_TOKEN),
-                                    newir_stmt(&A, JVST_IR_STMT_VALID),
-                                    NULL
-                                  )
+                                  newir_stmt(&A, JVST_IR_STMT_CONSUME)
                                 ),
 
                                 // match "bar"
                                 newir_case(&A, 1,
                                   newmatchset(&A, RE_LITERAL,  "bar", -1),
-                                  newir_bitop(&A, JVST_IR_STMT_BSET, 0, "reqmask", 2)
+                                  newir_seq(&A,
+                                    newir_bitop(&A, JVST_IR_STMT_BSET, 0, "reqmask", 2),
+                                    newir_stmt(&A, JVST_IR_STMT_CONSUME),
+                                    NULL
+                                  )
                                 ),
 
                                 // match "foo"
                                 newir_case(&A, 2,
                                   newmatchset(&A, RE_LITERAL,  "foo", -1),
-                                  newir_bitop(&A, JVST_IR_STMT_BSET, 0, "reqmask", 1)
+                                  newir_seq(&A,
+                                    newir_bitop(&A, JVST_IR_STMT_BSET, 0, "reqmask", 1),
+                                    newir_stmt(&A, JVST_IR_STMT_CONSUME),
+                                    NULL
+                                  )
                                 ),
 
                                 // match "quux"
                                 newir_case(&A, 3,
                                   newmatchset(&A, RE_LITERAL,  "quux", -1),
-                                  newir_bitop(&A, JVST_IR_STMT_BSET, 0, "reqmask", 0)
+                                  newir_seq(&A,
+                                    newir_bitop(&A, JVST_IR_STMT_BSET, 0, "reqmask", 0),
+                                    newir_stmt(&A, JVST_IR_STMT_CONSUME),
+                                    NULL
+                                  )
                                 ),
 
                                 NULL
@@ -1276,11 +1252,7 @@ void test_ir_dependencies(void)
                               // no match
                               newir_case(&A, 0, 
                                 NULL,
-                                newir_frame(&A,
-                                  newir_stmt(&A, JVST_IR_STMT_TOKEN),
-                                  newir_stmt(&A, JVST_IR_STMT_VALID),
-                                  NULL
-                                )
+                                newir_stmt(&A, JVST_IR_STMT_CONSUME)
                               ),
 
                               // match "bar"
@@ -1315,29 +1287,37 @@ void test_ir_dependencies(void)
                               // no match
                               newir_case(&A, 0, 
                                 NULL,
-                                newir_frame(&A,
-                                  newir_stmt(&A, JVST_IR_STMT_TOKEN),
-                                  newir_stmt(&A, JVST_IR_STMT_VALID),
-                                  NULL
-                                )
+                                newir_stmt(&A, JVST_IR_STMT_CONSUME)
                               ),
 
                               // match "bar"
                               newir_case(&A, 1,
                                 newmatchset(&A, RE_LITERAL,  "bar", -1),
-                                newir_bitop(&A, JVST_IR_STMT_BSET, 0, "reqmask", 2)
+                                newir_seq(&A,
+                                  newir_bitop(&A, JVST_IR_STMT_BSET, 0, "reqmask", 2),
+                                  newir_stmt(&A, JVST_IR_STMT_CONSUME),
+                                  NULL
+                                )
                               ),
 
                               // match "foo"
                               newir_case(&A, 2,
                                 newmatchset(&A, RE_LITERAL,  "foo", -1),
-                                newir_bitop(&A, JVST_IR_STMT_BSET, 0, "reqmask", 1)
+                                newir_seq(&A,
+                                  newir_bitop(&A, JVST_IR_STMT_BSET, 0, "reqmask", 1),
+                                  newir_stmt(&A, JVST_IR_STMT_CONSUME),
+                                  NULL
+                                )
                               ),
 
                               // match "quux"
                               newir_case(&A, 3,
                                 newmatchset(&A, RE_LITERAL,  "quux", -1),
-                                newir_bitop(&A, JVST_IR_STMT_BSET, 0, "reqmask", 0)
+                                newir_seq(&A,
+                                  newir_bitop(&A, JVST_IR_STMT_BSET, 0, "reqmask", 0),
+                                  newir_stmt(&A, JVST_IR_STMT_CONSUME),
+                                  NULL
+                                )
                               ),
 
                               NULL
@@ -1370,11 +1350,7 @@ void test_ir_dependencies(void)
                               // no match
                               newir_case(&A, 0, 
                                 NULL,
-                                newir_frame(&A,
-                                  newir_stmt(&A, JVST_IR_STMT_TOKEN),
-                                  newir_stmt(&A, JVST_IR_STMT_VALID),
-                                  NULL
-                                )
+                                newir_stmt(&A, JVST_IR_STMT_CONSUME)
                               ),
 
                               // match "bar"
@@ -1409,23 +1385,27 @@ void test_ir_dependencies(void)
                               // no match
                               newir_case(&A, 0, 
                                 NULL,
-                                newir_frame(&A,
-                                  newir_stmt(&A, JVST_IR_STMT_TOKEN),
-                                  newir_stmt(&A, JVST_IR_STMT_VALID),
-                                  NULL
-                                )
+                                newir_stmt(&A, JVST_IR_STMT_CONSUME)
                               ),
 
                               // match "quux"
                               newir_case(&A, 1,
                                 newmatchset(&A, RE_LITERAL,  "that", -1),
-                                newir_bitop(&A, JVST_IR_STMT_BSET, 0, "reqmask", 1)
+                                newir_seq(&A, 
+                                  newir_bitop(&A, JVST_IR_STMT_BSET, 0, "reqmask", 1),
+                                  newir_stmt(&A, JVST_IR_STMT_CONSUME),
+                                  NULL
+                                )
                               ),
 
                               // match "bar"
                               newir_case(&A, 2,
                                 newmatchset(&A, RE_LITERAL,  "this", -1),
-                                newir_bitop(&A, JVST_IR_STMT_BSET, 0, "reqmask", 0)
+                                newir_seq(&A, 
+                                  newir_bitop(&A, JVST_IR_STMT_BSET, 0, "reqmask", 0),
+                                  newir_stmt(&A, JVST_IR_STMT_CONSUME),
+                                  NULL
+                                )
                               ),
 
                               NULL

--- a/tests/validate_testing.h
+++ b/tests/validate_testing.h
@@ -193,6 +193,9 @@ jvst_ret2name(int ret);
 int
 report_tests(void);
 
+void
+buffer_diff(FILE *f, const char *buf1, const char *buf2, size_t n);
+
 #endif /* TESTING_H */
 
 /* vim: set tabstop=8 shiftwidth=8 noexpandtab: */


### PR DESCRIPTION
This is mainly to simplify testing, but it's always good to keep things as deterministic as possible.