### PR TITLE
Adds additionalProperties constraint

### DIFF
--- a/src/ast.h
+++ b/src/ast.h
@@ -166,7 +166,7 @@ struct ast_schema {
 	/*
 	 * "additionalProperties": schema set
 	 */
-	struct ast_schema_set *additional_properties;
+	struct ast_schema *additional_properties;
 
 	/* "dependencies": array form */
 	struct {

--- a/src/ast.h
+++ b/src/ast.h
@@ -164,12 +164,9 @@ struct ast_schema {
 	} properties;
 
 	/*
-	 * "additionalProperties": keyed by string literal
+	 * "additionalProperties": schema set
 	 */
-	struct {
-		struct ast_property_schema *set;
-		struct fsm *fsm; /* union to one dfa */
-	} additional_properties;
+	struct ast_schema_set *additional_properties;
 
 	/* "dependencies": array form */
 	struct {

--- a/src/parser.act
+++ b/src/parser.act
@@ -360,11 +360,29 @@
         @};
 
         <set-properties>:           (ps :ast-prop-schema) -> () = @{
+                struct ast_property_schema *ps, **pspp;
+
+                ps = @ps;
+
 		if (debug & DEBUG_ACT) {
                         // XXX - make this useful!
-			fprintf(stderr, "<set-properties>: %p\n", (void *) @ps);
+			fprintf(stderr, "<set-properties>: %p\n", (void *) ps);
 		}
-                ast->properties.set = @ps;
+
+                // search for end
+                for (pspp = &ast->properties.set; *pspp != NULL; pspp = &(*pspp)->next) {
+                        continue;
+                }
+
+                *pspp = ps;
+        @};
+
+        <set-additional-properties>:    (sch :ast-schema) -> () = @{
+		if (debug & DEBUG_ACT) {
+                        // XXX - make this useful!
+			fprintf(stderr, "<set-additional-properties>: %p\n", (void *) @sch);
+		}
+                ast->additional_properties = @sch;
         @};
 
         <new-schema-list>: () -> (lst :ast-schema-list) = @{

--- a/src/parser.sid
+++ b/src/parser.sid
@@ -95,6 +95,8 @@
 	<set-title>:                (:string) -> ();
 	<set-description>:          (:string) -> ();
         <set-properties>:           (:ast-prop-schema) -> ();
+        <set-additional-properties>:
+                                    (:ast-schema) -> ();
 
         <set-items-list>:           (:ast-schema-list) -> ();
         <set-items-single>:         (:ast-schema) -> ();
@@ -304,6 +306,11 @@
                 CCURLY;
         };
 
+        directive-additional-properties = {
+                sch = <parse-schema>;
+                <set-additional-properties>(sch);
+        };
+
         directive-pattern = {
                 s = STRING;
                 dialect = <re-pattern>;
@@ -459,7 +466,7 @@
 		directive-properties(dialect);
 	||
 		? = <kw-additional-properties>(k);
-		placeholder;
+                directive-additional-properties;
 	||
 		? = <kw-dependencies>(k);
 		placeholder;

--- a/src/validate_constraints.c
+++ b/src/validate_constraints.c
@@ -1040,26 +1040,9 @@ jvst_cnode_translate_ast(const struct ast_schema *ast)
 		struct jvst_cnode *constraint, **cpp, *pdft;
 		struct ast_schema_set *sset;
 
-		constraint = NULL;
-		cpp = &constraint;
-
-		for (sset = ast->additional_properties; sset != NULL; sset = sset->next) {
-			*cpp = jvst_cnode_translate_ast(sset->schema);
-			assert(*cpp != NULL);
-
-			cpp = &(*cpp)->next;
-		}
-
+		constraint = jvst_cnode_translate_ast(ast->additional_properties);
 		assert(constraint != NULL);
-
-		if (constraint->next != NULL) {
-			struct jvst_cnode *jxn;
-
-			// wrap multiple constraints with an AND
-			jxn = jvst_cnode_alloc(JVST_CNODE_AND);
-			jxn->u.ctrl = constraint;
-			constraint = jxn;
-		}
+		assert(constraint->next == NULL);
 
 		pdft = jvst_cnode_alloc(JVST_CNODE_OBJ_PROP_DEFAULT);
 		pdft->u.prop_default = constraint;

--- a/src/validate_constraints.c
+++ b/src/validate_constraints.c
@@ -2120,6 +2120,28 @@ jvst_cnode_simplify(struct jvst_cnode *tree)
 			return pset;
 		}
 
+	case JVST_CNODE_ARR_ITEM:
+	case JVST_CNODE_ARR_ADDITIONAL:
+		{
+			struct jvst_cnode *it, *next, *simplified_items, **spp;
+
+			simplified_items = NULL;
+			spp = &simplified_items;
+			for (it = tree->u.items; it != NULL; it = next) {
+				struct jvst_cnode *simplified;
+
+				next = it->next;
+
+				simplified = jvst_cnode_simplify(it);
+				*spp = simplified;
+				spp = &(*spp)->next;
+				*spp = NULL;
+			}
+
+			tree->u.items = simplified_items;
+			return tree;
+		}
+
 	case JVST_CNODE_MATCH_SWITCH:
 		{
 			struct jvst_cnode *mc, *next;
@@ -2146,8 +2168,6 @@ jvst_cnode_simplify(struct jvst_cnode *tree)
 	case JVST_CNODE_STR_MATCH:
 	case JVST_CNODE_OBJ_PROP_MATCH:
 	case JVST_CNODE_OBJ_REQUIRED:
-	case JVST_CNODE_ARR_ITEM:
-	case JVST_CNODE_ARR_ADDITIONAL:
 	case JVST_CNODE_OBJ_REQMASK:
 	case JVST_CNODE_OBJ_REQBIT:
 		// TODO: basic optimization for these nodes

--- a/src/validate_constraints.h
+++ b/src/validate_constraints.h
@@ -62,6 +62,7 @@ enum jvst_cnode_type {
 
 	JVST_CNODE_OBJ_PROP_SET,
 	JVST_CNODE_OBJ_PROP_MATCH,
+	JVST_CNODE_OBJ_PROP_DEFAULT,
 
 	JVST_CNODE_OBJ_REQUIRED,
 
@@ -131,6 +132,8 @@ struct jvst_cnode {
 			struct ast_regexp match;
 			struct jvst_cnode *constraint;
 		} prop_match;
+
+		struct jvst_cnode *prop_default;
 
 		// for array item and additional_item constraints
 		struct jvst_cnode *arr_item;

--- a/src/validate_ir.c
+++ b/src/validate_ir.c
@@ -1896,7 +1896,10 @@ ir_translate_obj_inner(struct jvst_cnode *top, struct ir_object_builder *builder
 			struct jvst_ir_stmt *frame, **spp, *matcher_stmt;
 
 			// duplicate DFA.
-			builder->matcher = fsm_clone(top->u.mswitch.dfa);
+			builder->matcher = NULL;
+			if (top->u.mswitch.dfa != NULL) {
+				builder->matcher = fsm_clone(top->u.mswitch.dfa);
+			}
 
 			// build jvst_ir_mcase nodes from cases list
 			which = 0;
@@ -1915,7 +1918,9 @@ ir_translate_obj_inner(struct jvst_cnode *top, struct ir_object_builder *builder
 			}
 
 			// replace MATCH_CASE opaque entries in DFA with their corresponding jvst_ir_mcase nodes
-			fsm_walk_states(builder->matcher, builder, obj_mcase_update_opaque);
+			if (builder->matcher != NULL) {
+				fsm_walk_states(builder->matcher, builder, obj_mcase_update_opaque);
+			}
 
 			// clear the castlist->u.mcase.tmp values in case they need to be used elsewhere
 			for (caselist = top->u.mswitch.cases; caselist != NULL; caselist = caselist->next) {

--- a/src/validate_ir.c
+++ b/src/validate_ir.c
@@ -35,6 +35,21 @@
 	abort();								\
 } while(0)
 
+#define UNKNOWN_CNODE(type) do { \
+	fprintf(stderr, "%s:%d (%s) unknown cnode type %d\n", \
+		__FILE__, __LINE__, __func__, (type)); 	   \
+	abort(); } while(0)
+
+#define UNKNOWN_STMT(type) do { \
+	fprintf(stderr, "%s:%d (%s) unknown statement type %d\n", \
+		__FILE__, __LINE__, __func__, (type)); 	   \
+	abort(); } while(0)
+
+#define UNKNOWN_EXPR(type) do { \
+	fprintf(stderr, "%s:%d (%s) unknown expression type %d\n", \
+		__FILE__, __LINE__, __func__, (type)); 	   \
+	abort(); } while(0)
+
 const char *
 jvst_invalid_msg(enum jvst_invalid_code code)
 {
@@ -537,9 +552,7 @@ ir_expr_tmp(struct jvst_ir_stmt *frame, struct jvst_ir_expr *expr)
 		abort();
 	}
 
-	fprintf(stderr, "%s:%d (%s) unknown expression type %d\n",
-		__FILE__, __LINE__, __func__, expr->type);
-	abort();
+	UNKNOWN_EXPR(expr->type);
 }
 
 static struct jvst_ir_expr *
@@ -1739,7 +1752,7 @@ obj_mcase_translate_inner(struct jvst_cnode *ctree, struct ir_object_builder *bu
 
 	case JVST_CNODE_VALID:
 		builder->consumed = true;
-		return ir_stmt_new(JVST_IR_STMT_VALID);
+		return ir_stmt_new(JVST_IR_STMT_CONSUME);
 
 	case JVST_CNODE_INVALID:
 		// XXX - better error message!
@@ -1772,15 +1785,13 @@ obj_mcase_translate(struct jvst_cnode *ctree, struct ir_object_builder *builder)
 	return stmt;
 }
 
-static struct jvst_ir_mcase *
-obj_mswitch_case_translate(struct jvst_cnode *node, struct ir_object_builder *builder)
+static struct jvst_ir_stmt *
+obj_mswitch_translate_and_ensure_consume(struct jvst_cnode *constraint, struct ir_object_builder *builder)
 {
 	bool prev_consumed;
 	struct jvst_ir_stmt *stmt;
-	struct jvst_ir_mcase *mcase;
 
-	assert(node->type == JVST_CNODE_MATCH_CASE);
-	assert(node->u.mcase.tmp == NULL);
+	assert(constraint != NULL);
 
 	/* XXX - why isn't this logic in obj_mcase_translate? */
 	/* ---> */
@@ -1791,7 +1802,7 @@ obj_mswitch_case_translate(struct jvst_cnode *node, struct ir_object_builder *bu
 	prev_consumed = builder->consumed;
 	builder->consumed = false;
 
-	stmt = obj_mcase_translate(node->u.mcase.constraint, builder);
+	stmt = obj_mcase_translate(constraint, builder);
 	if (!builder->consumed) {
 		struct jvst_ir_stmt *seq, **spp;
 		seq = ir_stmt_new(JVST_IR_STMT_SEQ);
@@ -1804,10 +1815,25 @@ obj_mswitch_case_translate(struct jvst_cnode *node, struct ir_object_builder *bu
 	}
 
 	builder->consumed = prev_consumed;
+	/* <--- */
+
+	return stmt;
+}
+
+static struct jvst_ir_mcase *
+obj_mswitch_case_translate(struct jvst_cnode *node, struct ir_object_builder *builder)
+{
+	bool prev_consumed;
+	struct jvst_ir_stmt *stmt;
+	struct jvst_ir_mcase *mcase;
+
+	assert(node->type == JVST_CNODE_MATCH_CASE);
+	assert(node->u.mcase.tmp == NULL);
+
+	stmt = obj_mswitch_translate_and_ensure_consume(node->u.mcase.constraint, builder);
 
 	mcase = ir_mcase_new(UNASSIGNED_MATCH, stmt);
 	mcase->matchset = node->u.mcase.matchset;
-	/* <--- */
 
 	node->u.mcase.tmp = mcase;
 
@@ -1857,6 +1883,7 @@ ir_translate_obj_inner(struct jvst_cnode *top, struct ir_object_builder *builder
 
 	case JVST_CNODE_OBJ_REQUIRED:
 	case JVST_CNODE_OBJ_PROP_SET:
+	case JVST_CNODE_OBJ_PROP_DEFAULT:
 		fprintf(stderr, "canonified cnode trees should not have %s nodes\n",
 			jvst_cnode_type_name(top->type));
 		abort();
@@ -1899,12 +1926,20 @@ ir_translate_obj_inner(struct jvst_cnode *top, struct ir_object_builder *builder
 
 			// 4. translate the default case
 			//
-			// Currently we do nothing, because the
-			// default_case is always VALID.
-			//
-			// FIXME: is default_case always VALID?  in that
-			// case we can eliminate it.  Otherwise, we need
-			// to do something more sophisticated here.
+			// XXX - Not sure that this will always do the
+			// right thing.  Need to revisit the translation
+			// of VALID/INVALID in obj_mcase_translate_inner,
+			// and refactor the whole translation.
+			{
+				struct jvst_cnode *cnode_dft;
+				struct jvst_ir_stmt *ir_dft;
+
+				cnode_dft = top->u.mswitch.default_case;
+				assert(cnode_dft != NULL);
+
+				ir_dft = obj_mswitch_translate_and_ensure_consume(cnode_dft, builder);
+				builder->match->u.match.default_case = ir_dft;
+			}
 
 			// 5. Add matcher statement to frame and fixup refs
 			matcher_stmt = ir_stmt_matcher(builder->frame, "dfa", builder->matcher);
@@ -2077,6 +2112,7 @@ cnode_and_requires_split(struct jvst_cnode *and_node)
 		case JVST_CNODE_NUM_INTEGER:
 		case JVST_CNODE_OBJ_PROP_SET:
 		case JVST_CNODE_OBJ_PROP_MATCH:
+		case JVST_CNODE_OBJ_PROP_DEFAULT:
 		case JVST_CNODE_OBJ_REQUIRED:
 		case JVST_CNODE_ARR_ITEM:
 		case JVST_CNODE_ARR_ADDITIONAL:
@@ -2152,6 +2188,7 @@ cnode_count_splits(struct jvst_cnode *top, size_t *np)
 	case JVST_CNODE_NUM_INTEGER:
 	case JVST_CNODE_OBJ_PROP_SET:
 	case JVST_CNODE_OBJ_PROP_MATCH:
+	case JVST_CNODE_OBJ_PROP_DEFAULT:
 	case JVST_CNODE_OBJ_REQUIRED:
 	case JVST_CNODE_ARR_ITEM:
 	case JVST_CNODE_ARR_ADDITIONAL:
@@ -2221,6 +2258,7 @@ separate_control_nodes(struct jvst_cnode *top, struct jvst_cnode **cpp, struct j
 		case JVST_CNODE_NUM_INTEGER:
 		case JVST_CNODE_OBJ_PROP_SET:
 		case JVST_CNODE_OBJ_PROP_MATCH:
+		case JVST_CNODE_OBJ_PROP_DEFAULT:
 		case JVST_CNODE_OBJ_REQUIRED:
 		case JVST_CNODE_ARR_ITEM:
 		case JVST_CNODE_ARR_ADDITIONAL:
@@ -2235,9 +2273,7 @@ separate_control_nodes(struct jvst_cnode *top, struct jvst_cnode **cpp, struct j
 			continue;
 		}
 
-		fprintf(stderr, "[%s:%d] unknown cnode type %d\n",
-				__FILE__, __LINE__, top->type);
-		abort();
+		UNKNOWN_CNODE(top->type);
 	}
 
 	return opp;
@@ -2430,6 +2466,7 @@ split_gather(struct jvst_cnode *top, struct split_gather_data *data)
 	case JVST_CNODE_NUM_INTEGER:
 	case JVST_CNODE_OBJ_PROP_SET:
 	case JVST_CNODE_OBJ_PROP_MATCH:
+	case JVST_CNODE_OBJ_PROP_DEFAULT:
 	case JVST_CNODE_OBJ_REQUIRED:
 	case JVST_CNODE_ARR_ITEM:
 	case JVST_CNODE_ARR_ADDITIONAL:
@@ -2444,9 +2481,7 @@ split_gather(struct jvst_cnode *top, struct split_gather_data *data)
 		abort();
 	}
 
-	// fail if the node type isn't handled in the switch
-	fprintf(stderr, "unknown cnode type %d\n", top->type);
-	abort();
+	UNKNOWN_CNODE(top->type);
 }
 
 static void
@@ -2814,6 +2849,7 @@ ir_translate_string_inner(struct jvst_cnode *top, struct ir_str_builder *builder
 	case JVST_CNODE_NUM_INTEGER:
 	case JVST_CNODE_OBJ_PROP_SET:
 	case JVST_CNODE_OBJ_PROP_MATCH:
+	case JVST_CNODE_OBJ_PROP_DEFAULT:
 	case JVST_CNODE_OBJ_REQUIRED:
 	case JVST_CNODE_ARR_ITEM:
 	case JVST_CNODE_ARR_ADDITIONAL:
@@ -2826,6 +2862,8 @@ ir_translate_string_inner(struct jvst_cnode *top, struct ir_str_builder *builder
 				jvst_cnode_type_name(top->type));
 		abort();
 	}
+
+	UNKNOWN_CNODE(top->type);
 }
 
 static struct jvst_ir_stmt *
@@ -3090,6 +3128,7 @@ ir_translate_array_inner(struct jvst_cnode *top, struct ir_arr_builder *builder)
 	case JVST_CNODE_OBJ_REQUIRED:
 	case JVST_CNODE_OBJ_PROP_SET:
 	case JVST_CNODE_OBJ_PROP_MATCH:
+	case JVST_CNODE_OBJ_PROP_DEFAULT:
 	case JVST_CNODE_STR_MATCH:
 		fprintf(stderr, "[%s:%d] cnode %s should not be be present in canonified cnode tree\n",
 				__FILE__, __LINE__, 
@@ -3110,6 +3149,8 @@ ir_translate_array_inner(struct jvst_cnode *top, struct ir_arr_builder *builder)
 				jvst_cnode_type_name(top->type));
 		abort();
 	}
+
+	UNKNOWN_CNODE(top->type);
 }
 
 static struct jvst_ir_stmt *

--- a/tests/unit/test_constraints.c
+++ b/tests/unit/test_constraints.c
@@ -389,6 +389,38 @@ void test_xlate_properties(void)
         SJP_NONE)
     },
 
+    {
+      TRANSLATE,
+      newschema_p(&A, 0,
+          "properties", newprops(&A,
+                          "foo", newschema(&A, JSON_VALUE_NUMBER), // XXX - JSON_VALUE_INTEGER
+                          "bar", newschema(&A, JSON_VALUE_STRING),
+                          NULL),
+          "additionalProperties", newschema(&A, JSON_VALUE_BOOL),
+          NULL),
+
+      NULL,
+
+      newcnode_switch(&A, 1,
+        SJP_OBJECT_BEG, newcnode_bool(&A,JVST_CNODE_AND,
+                          newcnode_prop_default(&A, 
+                            newcnode_switch(&A, 0,
+                              SJP_TRUE, newcnode_valid(),
+                              SJP_FALSE, newcnode_valid(),
+                              SJP_NONE)),
+                          newcnode_bool(&A,JVST_CNODE_AND,
+                            newcnode_propset(&A,
+                              newcnode_prop_match(&A, RE_LITERAL, "foo",
+                                newcnode_switch(&A, 0, SJP_NUMBER, newcnode_valid(), SJP_NONE)),
+                              newcnode_prop_match(&A, RE_LITERAL, "bar",
+                                newcnode_switch(&A, 0, SJP_STRING, newcnode_valid(), SJP_NONE)),
+                              NULL),
+                            newcnode_valid(),
+                            NULL),
+                          NULL),
+        SJP_NONE),
+    },
+
     { STOP },
   };
 
@@ -1360,6 +1392,43 @@ void test_simplify_propsets(void)
 
     },
 
+    {
+      SIMPLIFY,
+      NULL,
+
+      newcnode_switch(&A, 0,
+        SJP_OBJECT_BEG, newcnode_bool(&A,JVST_CNODE_AND,
+                          newcnode_prop_default(&A, 
+                            newcnode_switch(&A, 0,
+                              SJP_TRUE, newcnode_valid(),
+                              SJP_FALSE, newcnode_valid(),
+                              SJP_NONE)),
+                          newcnode_bool(&A,JVST_CNODE_AND,
+                            newcnode_propset(&A,
+                              newcnode_prop_match(&A, RE_LITERAL, "foo",
+                                newcnode_switch(&A, 0, SJP_NUMBER, newcnode_valid(), SJP_NONE)),
+                              newcnode_prop_match(&A, RE_LITERAL, "bar",
+                                newcnode_switch(&A, 0, SJP_STRING, newcnode_valid(), SJP_NONE)),
+                              NULL),
+                            newcnode_valid(),
+                            NULL),
+                          NULL),
+        SJP_NONE),
+
+        newcnode_switch(&A, 0,
+          SJP_OBJECT_BEG, newcnode_propset(&A,
+                            newcnode_prop_default(&A, 
+                              newcnode_switch(&A, 0,
+                                SJP_TRUE, newcnode_valid(),
+                                SJP_FALSE, newcnode_valid(),
+                                SJP_NONE)),
+                            newcnode_prop_match(&A, RE_LITERAL, "foo",
+                              newcnode_switch(&A, 0, SJP_NUMBER, newcnode_valid(), SJP_NONE)),
+                            newcnode_prop_match(&A, RE_LITERAL, "bar",
+                              newcnode_switch(&A, 0, SJP_STRING, newcnode_valid(), SJP_NONE)),
+                            NULL),
+          SJP_NONE)
+    },
     { STOP },
   };
 
@@ -1997,6 +2066,51 @@ void test_canonify_propsets(void)
                           NULL
                         ),
         SJP_NONE)
+    },
+
+    {
+      CANONIFY,
+      NULL,
+
+      newcnode_switch(&A, 0,
+        SJP_OBJECT_BEG, newcnode_bool(&A,JVST_CNODE_AND,
+                          newcnode_prop_default(&A, 
+                            newcnode_switch(&A, 0,
+                              SJP_TRUE, newcnode_valid(),
+                              SJP_FALSE, newcnode_valid(),
+                              SJP_NONE)),
+                          newcnode_bool(&A,JVST_CNODE_AND,
+                            newcnode_propset(&A,
+                              newcnode_prop_match(&A, RE_LITERAL, "foo",
+                                newcnode_switch(&A, 0, SJP_NUMBER, newcnode_valid(), SJP_NONE)),
+                              newcnode_prop_match(&A, RE_LITERAL, "bar",
+                                newcnode_switch(&A, 0, SJP_STRING, newcnode_valid(), SJP_NONE)),
+                              NULL),
+                            newcnode_valid(),
+                            NULL),
+                          NULL),
+        SJP_NONE),
+
+        newcnode_switch(&A, 0,
+          SJP_OBJECT_BEG, newcnode_mswitch(&A, 
+                            // default case
+                            newcnode_switch(&A, 0,
+                              SJP_TRUE, newcnode_valid(),
+                              SJP_FALSE, newcnode_valid(),
+                              SJP_NONE),
+
+                            newcnode_mcase(&A,
+                              newmatchset(&A, RE_LITERAL,  "bar", -1),
+                              newcnode_switch(&A, 0, SJP_STRING, newcnode_valid(), SJP_NONE)
+                            ),
+
+                            newcnode_mcase(&A,
+                              newmatchset(&A, RE_LITERAL, "foo", -1),
+                              newcnode_switch(&A, 0, SJP_NUMBER, newcnode_valid(), SJP_NONE)
+                            ),
+
+                            NULL),
+          SJP_NONE)
     },
 
     { STOP },

--- a/tests/unit/test_constraints.c
+++ b/tests/unit/test_constraints.c
@@ -1429,6 +1429,33 @@ void test_simplify_propsets(void)
                             NULL),
           SJP_NONE)
     },
+
+    {
+      SIMPLIFY,
+      NULL,
+
+      newcnode_switch(&A, 0,
+        SJP_OBJECT_BEG, newcnode_bool(&A,JVST_CNODE_AND,
+                          newcnode_prop_default(&A, 
+                            newcnode_switch(&A, 0,
+                              SJP_TRUE, newcnode_valid(),
+                              SJP_FALSE, newcnode_valid(),
+                              SJP_NONE)),
+                          newcnode_valid(),
+                          NULL),
+        SJP_NONE),
+
+        newcnode_switch(&A, 0,
+          SJP_OBJECT_BEG, newcnode_propset(&A,
+                            newcnode_prop_default(&A, 
+                              newcnode_switch(&A, 0,
+                                SJP_TRUE, newcnode_valid(),
+                                SJP_FALSE, newcnode_valid(),
+                                SJP_NONE)),
+                            NULL),
+          SJP_NONE)
+    },
+
     { STOP },
   };
 
@@ -2108,6 +2135,33 @@ void test_canonify_propsets(void)
                               newmatchset(&A, RE_LITERAL, "foo", -1),
                               newcnode_switch(&A, 0, SJP_NUMBER, newcnode_valid(), SJP_NONE)
                             ),
+
+                            NULL),
+          SJP_NONE)
+    },
+
+    {
+      CANONIFY,
+      NULL,
+
+      newcnode_switch(&A, 0,
+        SJP_OBJECT_BEG, newcnode_bool(&A,JVST_CNODE_AND,
+                          newcnode_prop_default(&A, 
+                            newcnode_switch(&A, 0,
+                              SJP_TRUE, newcnode_valid(),
+                              SJP_FALSE, newcnode_valid(),
+                              SJP_NONE)),
+                          newcnode_valid(),
+                          NULL),
+        SJP_NONE),
+
+        newcnode_switch(&A, 0,
+          SJP_OBJECT_BEG, newcnode_mswitch(&A, 
+                            // default case
+                            newcnode_switch(&A, 0,
+                              SJP_TRUE, newcnode_valid(),
+                              SJP_FALSE, newcnode_valid(),
+                              SJP_NONE),
 
                             NULL),
           SJP_NONE)

--- a/tests/unit/test_ir.c
+++ b/tests/unit/test_ir.c
@@ -756,6 +756,101 @@ void test_ir_properties(void)
     {
       TRANSLATE,
       newcnode_switch(&A, 1,
+        SJP_OBJECT_BEG, newcnode_bool(&A,JVST_CNODE_AND,
+                          newcnode_propset(&A,
+                            newcnode_prop_match(&A, RE_LITERAL, "foo",
+                              newcnode_switch(&A, 0, SJP_NUMBER, newcnode_valid(), SJP_NONE)),
+                            newcnode_prop_match(&A, RE_LITERAL, "bar",
+                              newcnode_switch(&A, 0, SJP_STRING, newcnode_valid(), SJP_NONE)),
+                            NULL),
+                          newcnode_prop_default(&A, 
+                            newcnode_switch(&A, 0,
+                              SJP_TRUE, newcnode_valid(),
+                              SJP_FALSE, newcnode_valid(),
+                              SJP_NONE)),
+                          NULL
+                        ),
+        SJP_NONE),
+
+      newir_frame(&A,
+          newir_matcher(&A, 0, "dfa"),
+          newir_stmt(&A, JVST_IR_STMT_TOKEN),
+          newir_if(&A, newir_istok(&A, SJP_OBJECT_BEG),
+            newir_seq(&A,
+              newir_loop(&A, "L_OBJ", 0,
+                newir_stmt(&A, JVST_IR_STMT_TOKEN),
+                newir_if(&A, newir_istok(&A, SJP_OBJECT_END),
+                  newir_break(&A, "L_OBJ", 0),
+                  newir_seq(&A,                                 // unnecessary SEQ should be removed in the future
+                    newir_match(&A, 0,
+                      // no match
+                      newir_case(&A, 0, 
+                        NULL,
+                        newir_frame(&A,
+                          newir_stmt(&A, JVST_IR_STMT_TOKEN),
+                          newir_if(&A, newir_istok(&A, SJP_TRUE),
+                            newir_stmt(&A, JVST_IR_STMT_VALID),
+                            newir_if(&A, newir_istok(&A, SJP_FALSE),
+                              newir_stmt(&A, JVST_IR_STMT_VALID),
+                              newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token")
+                            )
+                          ),
+                          NULL
+                        )
+                      ),
+
+                      // match "bar"
+                      newir_case(&A, 1,
+                        newmatchset(&A, RE_LITERAL,  "bar", -1),
+                        newir_frame(&A,
+                          newir_stmt(&A, JVST_IR_STMT_TOKEN),
+                          newir_if(&A, newir_istok(&A, SJP_STRING),
+                            newir_stmt(&A, JVST_IR_STMT_VALID),
+                            newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token")
+                          ),
+                          NULL
+                        )
+                      ),
+
+                      // match "foo"
+                      newir_case(&A, 2,
+                        newmatchset(&A, RE_LITERAL,  "foo", -1),
+                        newir_frame(&A,
+                          newir_stmt(&A, JVST_IR_STMT_TOKEN),
+                          newir_if(&A, newir_istok(&A, SJP_NUMBER),
+                            newir_stmt(&A, JVST_IR_STMT_VALID),
+                            newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token")
+                          ),
+                          NULL
+                        )
+                      ),
+
+                      NULL
+                    ),
+                    NULL
+                  )
+                ),
+                NULL
+              ),
+              newir_stmt(&A, JVST_IR_STMT_VALID),
+              NULL
+            ),
+
+            newir_if(&A, newir_istok(&A, SJP_OBJECT_END),
+              newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token"),
+              newir_if(&A, newir_istok(&A, SJP_ARRAY_END),
+                newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token"),
+                newir_stmt(&A, JVST_IR_STMT_VALID)
+              )
+            )
+          ),
+          NULL
+      )
+    },
+
+    {
+      TRANSLATE,
+      newcnode_switch(&A, 1,
         SJP_OBJECT_BEG, newcnode_propset(&A,
                           newcnode_prop_match(&A, RE_NATIVE, "ba.",
                             newcnode_switch(&A, 0, SJP_NUMBER, newcnode_valid(), SJP_NONE)),

--- a/tests/unit/validate_testing.c
+++ b/tests/unit/validate_testing.c
@@ -298,13 +298,9 @@ newschema_p(struct arena_info *A, int types, ...)
 			*pspp = prop_set;
 		} else if (strcmp(pname, "additionalProperties") == 0) {
 			struct ast_schema *sch;
-			struct ast_schema_set *sset;
 
 			sch = va_arg(args, struct ast_schema *);
-			sset = schema_set(A, sch, NULL);
-
-			sset->next = s->additional_properties;
-			s->additional_properties = sset;
+			s->additional_properties = sch;
 		} else if (strcmp(pname, "required") == 0) {
 			s->required.set = va_arg(args, struct ast_string_set *);
 		} else if (strcmp(pname, "minimum") == 0) {

--- a/tests/unit/validate_testing.c
+++ b/tests/unit/validate_testing.c
@@ -296,6 +296,15 @@ newschema_p(struct arena_info *A, int types, ...)
 				continue;
 			}
 			*pspp = prop_set;
+		} else if (strcmp(pname, "additionalProperties") == 0) {
+			struct ast_schema *sch;
+			struct ast_schema_set *sset;
+
+			sch = va_arg(args, struct ast_schema *);
+			sset = schema_set(A, sch, NULL);
+
+			sset->next = s->additional_properties;
+			s->additional_properties = sset;
 		} else if (strcmp(pname, "required") == 0) {
 			s->required.set = va_arg(args, struct ast_string_set *);
 		} else if (strcmp(pname, "minimum") == 0) {
@@ -598,6 +607,17 @@ newcnode_prop_match(struct arena_info *A, enum re_dialect dialect, const char *p
 	node->u.prop_match.match.str     = newstr(pat);
 	node->u.prop_match.match.fsm     = NULL;
 	node->u.prop_match.constraint    = constraint;
+
+	return node;
+}
+
+struct jvst_cnode *
+newcnode_prop_default(struct arena_info *A, struct jvst_cnode *dft)
+{
+	struct jvst_cnode *node;
+
+	node = newcnode(A, JVST_CNODE_OBJ_PROP_DEFAULT);
+	node->u.prop_default = dft;
 
 	return node;
 }

--- a/tests/unit/validate_testing.h
+++ b/tests/unit/validate_testing.h
@@ -96,6 +96,9 @@ struct jvst_cnode *
 newcnode_propset(struct arena_info *A, ...);
 
 struct jvst_cnode *
+newcnode_prop_default(struct arena_info *A, struct jvst_cnode *dft); 
+
+struct jvst_cnode *
 newcnode_bool(struct arena_info *A, enum jvst_cnode_type type, ...);
 
 struct jvst_cnode *


### PR DESCRIPTION
additionalProperties basically changes the default case in MATCH_SWITCH nodes.  Some care has to be taken for when additionalProperties is present and properties is not, so there's a default case but no specific matching cases.
