### PR TITLE
Exposes support for 'dependencies' constraints

### DIFF
--- a/src/parser.act
+++ b/src/parser.act
@@ -27,6 +27,8 @@
         re-dialect -> re_dialect_t;
         regexp     -> ast_regexp_t;
 
+	ast-string-set -> ast_string_set_t;
+
         ast-prop-schema -> ast_prop_schema_t;
         ast-schema -> ast_schema_t;
 
@@ -58,8 +60,14 @@
 	typedef enum kw kw;
 	typedef enum json_valuetype type;
 
-        typedef enum re_dialect re_dialect_t;
-        typedef struct ast_regexp ast_regexp_t;
+	typedef enum re_dialect re_dialect_t;
+	typedef struct ast_regexp ast_regexp_t;
+
+	struct string_set {
+		struct ast_string_set *head;
+		struct ast_string_set **tail;
+	};
+	typedef struct string_set *ast_string_set_t;
 
         typedef struct ast_schema *ast_schema_t;
         typedef struct ast_property_schema *ast_prop_schema_t;
@@ -751,6 +759,55 @@
 		}
 
 		ast->description = @s;
+	@};
+
+	<new-string-set>: () -> (ss :ast-string-set) = @{
+		struct string_set *ss;
+		ss = malloc(sizeof *ss);
+		ss->head = NULL;
+		ss->tail = &ss->head;
+		@ss = ss;
+	@};
+
+	<append-string-set>: (ss :ast-string-set, s :string) -> () = @{
+		struct string_set *ss = @ss;
+		struct ast_string_set *item;
+
+		item = malloc(sizeof *item);
+		item->str = @s;
+		item->next = NULL;
+		*ss->tail = item;
+		ss->tail = &item->next;
+	@};
+
+	<add-string-dependency>:    (n :string,ss :ast-string-set) -> () = @{
+		struct ast_property_names *pn;
+		struct string_set *ss;
+
+		ss = @ss;
+
+		pn = malloc(sizeof *pn);
+		pn->pattern.dialect = RE_LITERAL;
+		pn->pattern.str = @n;
+		pn->set = ss->head;
+
+		pn->next = ast->dependencies_strings.set;
+		ast->dependencies_strings.set = pn;
+	@};
+
+	<add-schema-dependency>:    (n :string, sch :ast-schema) -> () = @{
+		struct ast_property_schema *ps;
+		struct ast_schema *sch;
+
+		sch = @sch;
+
+		ps = malloc(sizeof *ps);
+		ps->pattern.dialect = RE_LITERAL;
+		ps->pattern.str = @n;
+		ps->schema = sch;
+
+		ps->next = ast->dependencies_schema.set;
+		ast->dependencies_schema.set = ps;
 	@};
 
 	<err-unimplemented> = @{

--- a/src/parser.sid
+++ b/src/parser.sid
@@ -15,6 +15,9 @@
         ast-schema;
         ast-schema-list;
         ast-prop-schema;
+
+	ast-string-set;
+
         regexp;
         re-dialect;
 
@@ -34,6 +37,12 @@
 	NULL;
 
 %productions%
+
+	/* some helpers */
+	<new-string-set>: () -> (:ast-string-set);
+	<append-string-set>: (:ast-string-set, :string) -> ();
+
+	/*** schema keywords ***/
 
 	<kw-lookup>:   (:string) -> (:kw);
 	<type-lookup>: (:string) -> (:type);
@@ -98,6 +107,9 @@
         <set-additional-properties>:
                                     (:ast-schema) -> ();
         <set-property-names>:       (:ast-schema) -> ();
+
+	<add-string-dependency>:    (:string,:ast-string-set) -> ();
+	<add-schema-dependency>:    (:string,:ast-schema) -> ();
 
         <set-items-list>:           (:ast-schema-list) -> ();
         <set-items-single>:         (:ast-schema) -> ();
@@ -322,6 +334,60 @@
                 <set-property-names>(sch);
         };
 
+	directive-dependencies [
+		single-dependency [
+			string-deps: () -> (ss :ast-string-set) [
+				list-of-strings: (ss :ast-string-set) -> () = {
+					s = STRING;
+					<append-string-set>(ss, s);
+					{
+						comma;
+						list-of-strings(ss);
+					||
+						$;
+					};
+				};
+			] = {
+				ss = <new-string-set>;
+				OBRACKET;
+				{
+					list-of-strings(ss);
+				||
+					$;
+				};
+				CBRACKET;
+			};
+		] = {
+			n = STRING;
+			colon;
+			{
+				ss = string-deps;
+				<add-string-dependency>(n,ss);
+			||
+				sch = <parse-schema>;
+				<add-schema-dependency>(n,sch);
+			};
+		};
+		
+		dependency-list = {
+			single-dependency;
+			{
+				comma;
+				dependency-list;
+			||
+				$;
+			};
+		};
+	] = {
+		OCURLY;
+		{
+			dependency-list;
+		||
+			$;
+		};
+		CCURLY;
+	};
+
         directive-pattern = {
                 s = STRING;
                 dialect = <re-pattern>;
@@ -503,7 +569,7 @@
                 directive-additional-properties;
 	||
 		? = <kw-dependencies>(k);
-		placeholder;
+		directive-dependencies;
 	||
 		? = <kw-property-names>(k);
 		directive-property-names;


### PR DESCRIPTION
The infrastructure for 'dependencies' constraints have been working for a while.  This adds support to the parser to add 'dependencies' constraints to the AST.

Builds on https://github.com/katef/jvst/pull/33
