### PR TITLE
Adds multipleOf constraint

### DIFF
--- a/src/validate_constraints.h
+++ b/src/validate_constraints.h
@@ -59,6 +59,7 @@ enum jvst_cnode_type {
 
 	JVST_CNODE_NUM_RANGE,
 	JVST_CNODE_NUM_INTEGER,
+	JVST_CNODE_NUM_MULTIPLE_OF,
 
 	JVST_CNODE_OBJ_PROP_SET,
 	JVST_CNODE_OBJ_PROP_MATCH,
@@ -123,6 +124,9 @@ struct jvst_cnode {
 			double min;
 			double max;
 		} num_range;
+
+		/* for multipleOf constraints */
+		double multiple_of;
 
 		/* support for required properties */
 		struct ast_string_set *required;

--- a/src/validate_ir.h
+++ b/src/validate_ir.h
@@ -76,6 +76,7 @@ enum jvst_ir_expr_type {
 	// literal values
 	JVST_IR_EXPR_NUM,		// literal number
 	JVST_IR_EXPR_INT,		// literal integer
+	JVST_IR_EXPR_MULTIPLE_OF,	// integer multiple of given number
 	JVST_IR_EXPR_SIZE,		// literal size
 	JVST_IR_EXPR_BOOL,		// literal boolean
 
@@ -141,6 +142,8 @@ enum jvst_invalid_code {
 	JVST_INVALID_TOO_FEW_ITEMS    = 0x000E,
 	JVST_INVALID_TOO_MANY_ITEMS   = 0x000F,
 	JVST_INVALID_UNSATISFIED_CONTAINS = 0x0010,
+
+	JVST_INVALID_NOT_MULTIPLE     = 0x0011,
 
 	JVST_INVALID_JSON             = 0x0020,
 
@@ -358,6 +361,11 @@ struct jvst_ir_expr {
 		struct {
 			struct jvst_ir_expr *arg;
 		} isint;
+
+		struct {
+			struct jvst_ir_expr *arg;
+			double divisor;
+		} multiple_of;
 
 		struct {
 			struct jvst_ir_stmt *frames;

--- a/src/validate_op.c
+++ b/src/validate_op.c
@@ -1,12 +1,14 @@
 #include "validate_op.h"
 
-#include <assert.h>
 #include <inttypes.h>
 #include <limits.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stddef.h>
 #include <string.h>
+#include <math.h>
+
+#include <assert.h>
 
 #include <fsm/fsm.h>
 #include <fsm/pred.h>
@@ -253,6 +255,10 @@ op_instr_dump(struct sbuf *buf, struct jvst_op_instr *instr)
 	case JVST_OP_FINT:
 		sbuf_snprintf(buf, "%s ", jvst_op_name(instr->op));
 		op_arg_dump(buf, instr->args[0]);
+		if (instr->args[1].type != JVST_VM_ARG_NONE) {
+			sbuf_snprintf(buf, ", ");
+			op_arg_dump(buf, instr->args[1]);
+		}
 		return;
 
 	case JVST_OP_BR:
@@ -1134,6 +1140,7 @@ ir_expr_type(enum jvst_ir_expr_type type)
 	case JVST_IR_EXPR_BTESTONE:
 	case JVST_IR_EXPR_ISTOK:
 	case JVST_IR_EXPR_ISINT:
+	case JVST_IR_EXPR_MULTIPLE_OF:
 	case JVST_IR_EXPR_NE:
 	case JVST_IR_EXPR_LT:
 	case JVST_IR_EXPR_LE:
@@ -1160,6 +1167,24 @@ static struct jvst_op_arg
 emit_match(struct op_assembler *opasm, struct jvst_ir_expr *expr);
 
 static struct jvst_op_arg
+emit_float_arg(struct op_assembler *opasm, double x)
+{
+	struct jvst_op_instr *instr;
+	int64_t fidx;
+	struct jvst_op_arg freg;
+
+	fidx = proc_add_float(opasm, x);
+	freg = arg_new_slot(opasm);
+
+	instr = op_instr_new(JVST_OP_FLOAD);
+	instr->args[0] = freg;
+	instr->args[1] = arg_const(fidx);
+	emit_instr(opasm, instr);
+
+	return freg;
+}
+
+static struct jvst_op_arg
 emit_op_arg(struct op_assembler *opasm, struct jvst_ir_expr *arg)
 {
 	struct jvst_op_arg a;
@@ -1169,19 +1194,7 @@ emit_op_arg(struct op_assembler *opasm, struct jvst_ir_expr *arg)
 		return arg_none();
 
 	case JVST_IR_EXPR_NUM:
-		{
-			int64_t fidx;
-			struct jvst_op_arg freg;
-			struct jvst_op_instr *instr;
-
-			fidx = proc_add_float(opasm, arg->u.vnum);
-			freg = arg_new_slot(opasm);
-			instr = op_instr_new(JVST_OP_FLOAD);
-			instr->args[0] = freg;
-			instr->args[1] = arg_const(fidx);
-			emit_instr(opasm, instr);
-			return freg;
-		}
+		return emit_float_arg(opasm, arg->u.vnum);
 
 	case JVST_IR_EXPR_TOK_TYPE:
 		return arg_special(JVST_VM_ARG_TT);
@@ -1275,6 +1288,7 @@ emit_op_arg(struct op_assembler *opasm, struct jvst_ir_expr *arg)
 	case JVST_IR_EXPR_BTESTONE:
 	case JVST_IR_EXPR_ISTOK:
 	case JVST_IR_EXPR_ISINT:
+	case JVST_IR_EXPR_MULTIPLE_OF:
 	case JVST_IR_EXPR_NE:
 	case JVST_IR_EXPR_LT:
 	case JVST_IR_EXPR_LE:
@@ -1332,6 +1346,7 @@ cmp_type(enum jvst_ir_expr_type type, enum jvst_vm_op *iopp, enum jvst_vm_op *fo
 	case JVST_IR_EXPR_NONE:
 	case JVST_IR_EXPR_ISTOK:
 	case JVST_IR_EXPR_ISINT:
+	case JVST_IR_EXPR_MULTIPLE_OF:
 	case JVST_IR_EXPR_AND:
 	case JVST_IR_EXPR_OR:
 	case JVST_IR_EXPR_NOT:
@@ -1431,6 +1446,20 @@ op_assemble_cond(struct op_assembler *opasm, struct jvst_ir_expr *cond)
 	case JVST_IR_EXPR_ISINT:
 		emit_cond(opasm, JVST_OP_FINT,
 			arg_special(JVST_VM_ARG_TNUM), arg_none());
+		return;
+
+	case JVST_IR_EXPR_MULTIPLE_OF:
+		{
+			struct jvst_op_arg a,b;
+			int64_t fidx;
+			double div;
+
+			div = cond->u.multiple_of.divisor;
+
+			b = emit_float_arg(opasm, div);
+			a = emit_op_arg(opasm, cond->u.multiple_of.arg);
+			emit_cond(opasm, JVST_OP_FINT, a,b);
+		}
 		return;
 
 	case JVST_IR_EXPR_NE:

--- a/src/validate_op.c
+++ b/src/validate_op.c
@@ -1456,7 +1456,11 @@ op_assemble_cond(struct op_assembler *opasm, struct jvst_ir_expr *cond)
 
 			div = cond->u.multiple_of.divisor;
 
-			b = emit_float_arg(opasm, div);
+			if (ceil(div) == div && div < MAX_CONST_VALUE) {
+				b = arg_const((int64_t)div);
+			} else {
+				b = emit_float_arg(opasm, div);
+			}
 			a = emit_op_arg(opasm, cond->u.multiple_of.arg);
 			emit_cond(opasm, JVST_OP_FINT, a,b);
 		}

--- a/src/validate_vm.c
+++ b/src/validate_vm.c
@@ -1192,13 +1192,26 @@ loop:
 	case JVST_OP_FINT:
 		{
 			double v;
-			uint32_t arg0;
+			uint32_t arg0, arg1;
 			int slot;
 
 			arg0 = jvst_vm_decode_arg0(opcode);
+			arg1 = jvst_vm_decode_arg1(opcode);
 			assert(jvst_vm_arg_isslot(arg0));
 
 			v = vm_fvalptr(vm, fp, arg0)[0];
+			if (arg1 != 0) {
+				double div;
+
+				if (jvst_vm_arg_isslot(arg1)) {
+					div = vm_fvalptr(vm, fp, arg1)[0];
+				} else {
+					div = jvst_vm_arg_tolit(arg1);
+				}
+
+				v /= div;
+			}
+
 			vm->r_flag = flag = isfinite(v) && (v == ceil(v));
 		}
 		NEXT;

--- a/tests/unit/test_constraints.c
+++ b/tests/unit/test_constraints.c
@@ -310,7 +310,7 @@ static void test_xlate_type_integer(void)
   RUNTESTS(tests);
 }
 
-void test_xlate_minimum(void)
+static void test_xlate_minimum(void)
 {
   struct arena_info A = {0};
   struct ast_schema *schema = newschema_p(&A, 0,
@@ -326,6 +326,33 @@ void test_xlate_minimum(void)
                       NULL),
         SJP_NONE),
     },
+    { STOP },
+  };
+
+  RUNTESTS(tests);
+}
+
+static void test_xlate_multiple_of(void)
+{
+  struct arena_info A = {0};
+
+  const struct cnode_test tests[] = {
+    {
+      TRANSLATE,
+      newschema_p(&A, 0,
+          "multipleOf", 3.0,
+          NULL),
+
+      NULL,
+
+      newcnode_switch(&A, 1,
+        SJP_NUMBER, newcnode_bool(&A, JVST_CNODE_AND,
+                      newcnode_multiple_of(&A, 3.0),
+                      newcnode_valid(),
+                      NULL),
+        SJP_NONE),
+    },
+
     { STOP },
   };
 
@@ -4305,6 +4332,7 @@ int main(void)
   test_xlate_type_integer();
 
   test_xlate_minimum();
+  test_xlate_multiple_of();
 
   test_xlate_properties();
   test_xlate_propertynames();

--- a/tests/unit/test_ir.c
+++ b/tests/unit/test_ir.c
@@ -586,6 +586,161 @@ void test_ir_minimum(void)
   RUNTESTS(tests);
 }
 
+void test_ir_multiple_of(void)
+{
+  struct arena_info A = {0};
+
+  const struct ir_test tests[] = {
+    {
+      TRANSLATE,
+      newcnode_switch(&A, 1,
+        SJP_NUMBER, newcnode_bool(&A, JVST_CNODE_AND,
+                      newcnode_multiple_of(&A, 3.0),
+                      newcnode_valid(),
+                      NULL),
+        SJP_NONE),
+
+      newir_frame(&A,
+          newir_stmt(&A, JVST_IR_STMT_TOKEN),
+          newir_if(&A, newir_istok(&A, SJP_NUMBER),
+            newir_if(&A, newir_multiple_of(&A, newir_expr(&A, JVST_IR_EXPR_TOK_NUM), 3.0),
+              newir_seq(&A,
+                newir_stmt(&A, JVST_IR_STMT_CONSUME),
+                newir_stmt(&A, JVST_IR_STMT_VALID),
+                NULL
+              ),
+              newir_invalid(&A, JVST_INVALID_NOT_MULTIPLE, "number is not an integer multiple")
+            ),
+            newir_if(&A, newir_istok(&A, SJP_OBJECT_END),
+              newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token"),
+              newir_if(&A, newir_istok(&A, SJP_ARRAY_END),
+                newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token"),
+                newir_seq(&A,
+                  newir_stmt(&A, JVST_IR_STMT_CONSUME),
+                  newir_stmt(&A, JVST_IR_STMT_VALID),
+                  NULL
+                )
+              )
+            )
+          ),
+          NULL
+      )
+    },
+
+    {
+      LINEARIZE,
+      newcnode_switch(&A, 1,
+        SJP_NUMBER, newcnode_bool(&A, JVST_CNODE_AND,
+                      newcnode_multiple_of(&A, 3.0),
+                      newcnode_valid(),
+                      NULL),
+        SJP_NONE),
+
+      newir_frame(&A,
+          newir_stmt(&A, JVST_IR_STMT_TOKEN),
+          newir_if(&A, newir_istok(&A, SJP_NUMBER),
+            newir_if(&A, newir_multiple_of(&A, newir_expr(&A, JVST_IR_EXPR_TOK_NUM), 3.0),
+              newir_seq(&A,
+                newir_stmt(&A, JVST_IR_STMT_CONSUME),
+                newir_stmt(&A, JVST_IR_STMT_VALID),
+                NULL
+              ),
+              newir_invalid(&A, JVST_INVALID_NOT_MULTIPLE, "number is not an integer multiple")
+            ),
+            newir_if(&A, newir_istok(&A, SJP_OBJECT_END),
+              newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token"),
+              newir_if(&A, newir_istok(&A, SJP_ARRAY_END),
+                newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token"),
+                newir_seq(&A,
+                  newir_stmt(&A, JVST_IR_STMT_CONSUME),
+                  newir_stmt(&A, JVST_IR_STMT_VALID),
+                  NULL
+                )
+              )
+            )
+          ),
+          NULL
+      ),
+
+      newir_program(&A,
+        newir_frame(&A, frameindex, 1,
+          newir_block(&A, 0, "entry",
+            newir_stmt(&A, JVST_IR_STMT_TOKEN),
+            newir_cbranch(&A, newir_istok(&A, SJP_NUMBER),
+              2, "true",
+              8, "false"
+            ),
+            NULL
+          ),
+
+          newir_block(&A, 8, "false",
+            newir_cbranch(&A, newir_istok(&A, SJP_OBJECT_END),
+              11, "invalid_1",
+              12, "false"
+            ),
+            NULL
+          ),
+
+          newir_block(&A, 12, "false",
+            newir_cbranch(&A, newir_istok(&A, SJP_ARRAY_END),
+              11, "invalid_1",
+              15, "false"
+            ),
+            NULL
+          ),
+
+          newir_block(&A, 15, "false",
+            newir_stmt(&A, JVST_IR_STMT_CONSUME),
+            newir_branch(&A, 5, "valid"),
+            NULL
+          ),
+
+          newir_block(&A, 5, "valid",
+            newir_stmt(&A, JVST_IR_STMT_VALID),
+            NULL
+          ),
+
+          newir_block(&A, 2, "true",
+            newir_cbranch(&A,
+              newir_multiple_of(&A,
+                newir_expr(&A, JVST_IR_EXPR_TOK_NUM),
+                3.0),
+              4, "true",
+              7, "invalid_17"
+            ),
+            NULL
+          ),
+
+          newir_block(&A, 7, "invalid_17",
+            newir_invalid(&A, JVST_INVALID_NOT_MULTIPLE, "number is not an integer multiple"),
+            NULL
+          ),
+
+          newir_block(&A, 4, "true",
+            newir_stmt(&A, JVST_IR_STMT_CONSUME),
+            newir_branch(&A, 5, "valid"),
+            NULL
+          ),
+
+          newir_block(&A, 11, "invalid_1",
+            newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token"),
+            NULL
+          ),
+
+          NULL
+        ),
+
+        NULL
+      )
+
+    },
+
+    { STOP },
+  };
+
+  RUNTESTS(tests);
+}
+
 void test_ir_properties(void)
 {
   struct arena_info A = {0};
@@ -5942,6 +6097,7 @@ int main(void)
 
   test_ir_type_integer();
   test_ir_minimum();
+  test_ir_multiple_of();
 
   test_ir_properties();
 

--- a/tests/unit/test_op.c
+++ b/tests/unit/test_op.c
@@ -657,7 +657,7 @@ static void test_op_type_integer(void)
   RUNTESTS(tests);
 }
 
-void test_op_minimum(void)
+static void test_op_minimum(void)
 {
   struct arena_info A = {0};
   struct ast_schema *schema = newschema_p(&A, 0,
@@ -850,7 +850,215 @@ void test_op_minimum(void)
   RUNTESTS(tests);
 }
 
-void test_op_properties(void)
+static void test_op_multiple_of(void)
+{
+  struct arena_info A = {0};
+
+  const struct op_test tests[] = {
+    {
+      ASSEMBLE,
+      newcnode_switch(&A, 1,
+          SJP_NUMBER, newcnode_multiple_of(&A, 3.0),
+          SJP_NONE),
+
+      newir_frame(&A,
+          newir_stmt(&A, JVST_IR_STMT_TOKEN),
+          newir_if(&A, newir_istok(&A, SJP_NUMBER),
+            newir_if(&A, newir_multiple_of(&A, newir_expr(&A, JVST_IR_EXPR_TOK_NUM), 3.0),
+              newir_seq(&A,
+                newir_stmt(&A, JVST_IR_STMT_CONSUME),
+                newir_stmt(&A, JVST_IR_STMT_VALID),
+                NULL
+              ),
+              newir_invalid(&A, JVST_INVALID_NOT_MULTIPLE, "number is not an integer multiple")
+            ),
+            newir_if(&A, newir_istok(&A, SJP_OBJECT_END),
+              newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token"),
+              newir_if(&A, newir_istok(&A, SJP_ARRAY_END),
+                newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token"),
+                newir_seq(&A,
+                  newir_stmt(&A, JVST_IR_STMT_CONSUME),
+                  newir_stmt(&A, JVST_IR_STMT_VALID),
+                  NULL
+                )
+              )
+            )
+          ),
+          NULL
+      ),
+
+      newop_program(&A,
+          opfloat, 3.0,
+
+          newop_proc(&A,
+            opslots, 1,
+
+            oplabel, "entry_0",
+            newop_instr(&A, JVST_OP_TOKEN),
+            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_NUMBER)),
+            newop_br(&A, JVST_OP_CBT, "true_2"),
+
+            oplabel, "false_8",
+            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_OP_CBT, "invalid_1_11"),
+
+            oplabel, "false_12",
+            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
+            newop_br(&A, JVST_OP_CBT, "invalid_1_11"),
+
+            oplabel, "false_15",
+            newop_instr(&A, JVST_OP_CONSUME),
+
+            oplabel, "valid_5",
+            newop_instr(&A, JVST_OP_VALID),
+
+            oplabel, "true_2",
+            newop_load(&A, JVST_OP_FLOAD, oparg_slot(0), oparg_lit(0)),
+            newop_cmp(&A, JVST_OP_FINT, oparg_tnum(), oparg_slot(0)),
+            newop_br(&A, JVST_OP_CBT, "true_4"),
+
+            oplabel, "invalid_17_7",
+            newop_invalid(&A, 17),
+
+            oplabel, "true_4",
+            newop_instr(&A, JVST_OP_CONSUME),
+            newop_br(&A, JVST_OP_BR, "valid_5"),
+
+            oplabel, "invalid_1_11",
+            newop_invalid(&A, 1),
+
+            NULL
+          ),
+
+          NULL
+      ),
+
+    },
+
+    {
+      ENCODE,
+      newcnode_switch(&A, 1,
+          SJP_NUMBER, newcnode_multiple_of(&A, 3.0),
+          SJP_NONE),
+
+      newir_frame(&A,
+          newir_stmt(&A, JVST_IR_STMT_TOKEN),
+          newir_if(&A, newir_istok(&A, SJP_NUMBER),
+            newir_if(&A, newir_multiple_of(&A, newir_expr(&A, JVST_IR_EXPR_TOK_NUM), 3.0),
+              newir_seq(&A,
+                newir_stmt(&A, JVST_IR_STMT_CONSUME),
+                newir_stmt(&A, JVST_IR_STMT_VALID),
+                NULL
+              ),
+              newir_invalid(&A, JVST_INVALID_NOT_MULTIPLE, "number is not an integer multiple")
+            ),
+            newir_if(&A, newir_istok(&A, SJP_OBJECT_END),
+              newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token"),
+              newir_if(&A, newir_istok(&A, SJP_ARRAY_END),
+                newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token"),
+                newir_seq(&A,
+                  newir_stmt(&A, JVST_IR_STMT_CONSUME),
+                  newir_stmt(&A, JVST_IR_STMT_VALID),
+                  NULL
+                )
+              )
+            )
+          ),
+          NULL
+      ),
+
+      newop_program(&A,
+          opfloat, 3.0,
+
+          newop_proc(&A,
+            opslots, 1,
+
+            oplabel, "entry_0",
+            newop_instr(&A, JVST_OP_TOKEN),
+            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_NUMBER)),
+            newop_br(&A, JVST_OP_CBT, "true_2"),
+
+            oplabel, "false_8",
+            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_OP_CBT, "invalid_1_11"),
+
+            oplabel, "false_12",
+            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
+            newop_br(&A, JVST_OP_CBT, "invalid_1_11"),
+
+            oplabel, "false_15",
+            newop_instr(&A, JVST_OP_CONSUME),
+
+            oplabel, "valid_5",
+            newop_instr(&A, JVST_OP_VALID),
+
+            oplabel, "true_2",
+            newop_load(&A, JVST_OP_FLOAD, oparg_slot(0), oparg_lit(0)),
+            newop_cmp(&A, JVST_OP_FINT, oparg_tnum(), oparg_slot(0)),
+            newop_br(&A, JVST_OP_CBT, "true_4"),
+
+            oplabel, "invalid_17_7",
+            newop_invalid(&A, 17),
+
+            oplabel, "true_4",
+            newop_instr(&A, JVST_OP_CONSUME),
+            newop_br(&A, JVST_OP_BR, "valid_5"),
+
+            oplabel, "invalid_1_11",
+            newop_invalid(&A, 1),
+
+            NULL
+          ),
+
+          NULL
+      ),
+
+      newvm_program(&A,
+          VM_FLOATS, 1, 3.0,
+
+          JVST_OP_PROC, VMLIT(1), VMLIT(0),
+          JVST_OP_TOKEN, 0, 0,
+          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_NUMBER),
+          JVST_OP_CBT, "true_2",
+
+          VM_LABEL, "false_8",
+          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_END),
+          JVST_OP_CBT, "invalid_1_11",
+
+          VM_LABEL, "false_12",
+          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_ARRAY_END),
+          JVST_OP_CBT, "invalid_1_11",
+
+          VM_LABEL, "false_15",
+          JVST_OP_CONSUME, 0, 0,
+
+          VM_LABEL, "valid_5",
+          JVST_OP_VALID, 0, 0,
+
+          VM_LABEL, "true_2",
+          JVST_OP_FLOAD, VMSLOT(0), VMLIT(0),
+          JVST_OP_FINT, VMREG(JVST_VM_TNUM), VMSLOT(0),
+          JVST_OP_CBT, "true_4",
+
+          JVST_OP_INVALID, VMLIT(17), 0,
+
+          VM_LABEL, "true_4",
+          JVST_OP_CONSUME, 0, 0,
+          JVST_OP_BR, "valid_5",
+
+          VM_LABEL, "invalid_1_11",
+          JVST_OP_INVALID, VMLIT(1), 0,
+
+          VM_END)
+    },
+
+    { STOP },
+  };
+
+  RUNTESTS(tests);
+}
+
+static void test_op_properties(void)
 {
   struct arena_info A = {0};
 
@@ -4340,6 +4548,7 @@ int main(void)
 
   test_op_type_integer();
   test_op_minimum();
+  test_op_multiple_of();
 
   test_op_properties();
 

--- a/tests/unit/test_op.c
+++ b/tests/unit/test_op.c
@@ -858,6 +858,203 @@ static void test_op_multiple_of(void)
     {
       ASSEMBLE,
       newcnode_switch(&A, 1,
+          SJP_NUMBER, newcnode_multiple_of(&A, 1.5),
+          SJP_NONE),
+
+      newir_frame(&A,
+          newir_stmt(&A, JVST_IR_STMT_TOKEN),
+          newir_if(&A, newir_istok(&A, SJP_NUMBER),
+            newir_if(&A, newir_multiple_of(&A, newir_expr(&A, JVST_IR_EXPR_TOK_NUM), 1.5),
+              newir_seq(&A,
+                newir_stmt(&A, JVST_IR_STMT_CONSUME),
+                newir_stmt(&A, JVST_IR_STMT_VALID),
+                NULL
+              ),
+              newir_invalid(&A, JVST_INVALID_NOT_MULTIPLE, "number is not an integer multiple")
+            ),
+            newir_if(&A, newir_istok(&A, SJP_OBJECT_END),
+              newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token"),
+              newir_if(&A, newir_istok(&A, SJP_ARRAY_END),
+                newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token"),
+                newir_seq(&A,
+                  newir_stmt(&A, JVST_IR_STMT_CONSUME),
+                  newir_stmt(&A, JVST_IR_STMT_VALID),
+                  NULL
+                )
+              )
+            )
+          ),
+          NULL
+      ),
+
+      newop_program(&A,
+          opfloat, 1.5,
+
+          newop_proc(&A,
+            opslots, 1,
+
+            oplabel, "entry_0",
+            newop_instr(&A, JVST_OP_TOKEN),
+            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_NUMBER)),
+            newop_br(&A, JVST_OP_CBT, "true_2"),
+
+            oplabel, "false_8",
+            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_OP_CBT, "invalid_1_11"),
+
+            oplabel, "false_12",
+            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
+            newop_br(&A, JVST_OP_CBT, "invalid_1_11"),
+
+            oplabel, "false_15",
+            newop_instr(&A, JVST_OP_CONSUME),
+
+            oplabel, "valid_5",
+            newop_instr(&A, JVST_OP_VALID),
+
+            oplabel, "true_2",
+            newop_load(&A, JVST_OP_FLOAD, oparg_slot(0), oparg_lit(0)),
+            newop_cmp(&A, JVST_OP_FINT, oparg_tnum(), oparg_slot(0)),
+            newop_br(&A, JVST_OP_CBT, "true_4"),
+
+            oplabel, "invalid_17_7",
+            newop_invalid(&A, 17),
+
+            oplabel, "true_4",
+            newop_instr(&A, JVST_OP_CONSUME),
+            newop_br(&A, JVST_OP_BR, "valid_5"),
+
+            oplabel, "invalid_1_11",
+            newop_invalid(&A, 1),
+
+            NULL
+          ),
+
+          NULL
+      ),
+
+    },
+
+    {
+      ENCODE,
+      newcnode_switch(&A, 1,
+          SJP_NUMBER, newcnode_multiple_of(&A, 1.5),
+          SJP_NONE),
+
+      newir_frame(&A,
+          newir_stmt(&A, JVST_IR_STMT_TOKEN),
+          newir_if(&A, newir_istok(&A, SJP_NUMBER),
+            newir_if(&A, newir_multiple_of(&A, newir_expr(&A, JVST_IR_EXPR_TOK_NUM), 1.5),
+              newir_seq(&A,
+                newir_stmt(&A, JVST_IR_STMT_CONSUME),
+                newir_stmt(&A, JVST_IR_STMT_VALID),
+                NULL
+              ),
+              newir_invalid(&A, JVST_INVALID_NOT_MULTIPLE, "number is not an integer multiple")
+            ),
+            newir_if(&A, newir_istok(&A, SJP_OBJECT_END),
+              newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token"),
+              newir_if(&A, newir_istok(&A, SJP_ARRAY_END),
+                newir_invalid(&A, JVST_INVALID_UNEXPECTED_TOKEN, "unexpected token"),
+                newir_seq(&A,
+                  newir_stmt(&A, JVST_IR_STMT_CONSUME),
+                  newir_stmt(&A, JVST_IR_STMT_VALID),
+                  NULL
+                )
+              )
+            )
+          ),
+          NULL
+      ),
+
+      newop_program(&A,
+          opfloat, 1.5,
+
+          newop_proc(&A,
+            opslots, 1,
+
+            oplabel, "entry_0",
+            newop_instr(&A, JVST_OP_TOKEN),
+            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_NUMBER)),
+            newop_br(&A, JVST_OP_CBT, "true_2"),
+
+            oplabel, "false_8",
+            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_OP_CBT, "invalid_1_11"),
+
+            oplabel, "false_12",
+            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
+            newop_br(&A, JVST_OP_CBT, "invalid_1_11"),
+
+            oplabel, "false_15",
+            newop_instr(&A, JVST_OP_CONSUME),
+
+            oplabel, "valid_5",
+            newop_instr(&A, JVST_OP_VALID),
+
+            oplabel, "true_2",
+            newop_load(&A, JVST_OP_FLOAD, oparg_slot(0), oparg_lit(0)),
+            newop_cmp(&A, JVST_OP_FINT, oparg_tnum(), oparg_slot(0)),
+            newop_br(&A, JVST_OP_CBT, "true_4"),
+
+            oplabel, "invalid_17_7",
+            newop_invalid(&A, 17),
+
+            oplabel, "true_4",
+            newop_instr(&A, JVST_OP_CONSUME),
+            newop_br(&A, JVST_OP_BR, "valid_5"),
+
+            oplabel, "invalid_1_11",
+            newop_invalid(&A, 1),
+
+            NULL
+          ),
+
+          NULL
+      ),
+
+      newvm_program(&A,
+          VM_FLOATS, 1, 1.5,
+
+          JVST_OP_PROC, VMLIT(1), VMLIT(0),
+          JVST_OP_TOKEN, 0, 0,
+          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_NUMBER),
+          JVST_OP_CBT, "true_2",
+
+          VM_LABEL, "false_8",
+          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_END),
+          JVST_OP_CBT, "invalid_1_11",
+
+          VM_LABEL, "false_12",
+          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_ARRAY_END),
+          JVST_OP_CBT, "invalid_1_11",
+
+          VM_LABEL, "false_15",
+          JVST_OP_CONSUME, 0, 0,
+
+          VM_LABEL, "valid_5",
+          JVST_OP_VALID, 0, 0,
+
+          VM_LABEL, "true_2",
+          JVST_OP_FLOAD, VMSLOT(0), VMLIT(0),
+          JVST_OP_FINT, VMREG(JVST_VM_TNUM), VMSLOT(0),
+          JVST_OP_CBT, "true_4",
+
+          JVST_OP_INVALID, VMLIT(17), 0,
+
+          VM_LABEL, "true_4",
+          JVST_OP_CONSUME, 0, 0,
+          JVST_OP_BR, "valid_5",
+
+          VM_LABEL, "invalid_1_11",
+          JVST_OP_INVALID, VMLIT(1), 0,
+
+          VM_END)
+    },
+
+    {
+      ASSEMBLE,
+      newcnode_switch(&A, 1,
           SJP_NUMBER, newcnode_multiple_of(&A, 3.0),
           SJP_NONE),
 
@@ -888,11 +1085,7 @@ static void test_op_multiple_of(void)
       ),
 
       newop_program(&A,
-          opfloat, 3.0,
-
           newop_proc(&A,
-            opslots, 1,
-
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
             newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_NUMBER)),
@@ -913,8 +1106,7 @@ static void test_op_multiple_of(void)
             newop_instr(&A, JVST_OP_VALID),
 
             oplabel, "true_2",
-            newop_load(&A, JVST_OP_FLOAD, oparg_slot(0), oparg_lit(0)),
-            newop_cmp(&A, JVST_OP_FINT, oparg_tnum(), oparg_slot(0)),
+            newop_cmp(&A, JVST_OP_FINT, oparg_tnum(), oparg_lit(3)),
             newop_br(&A, JVST_OP_CBT, "true_4"),
 
             oplabel, "invalid_17_7",
@@ -968,11 +1160,7 @@ static void test_op_multiple_of(void)
       ),
 
       newop_program(&A,
-          opfloat, 3.0,
-
           newop_proc(&A,
-            opslots, 1,
-
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
             newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_NUMBER)),
@@ -1014,9 +1202,7 @@ static void test_op_multiple_of(void)
       ),
 
       newvm_program(&A,
-          VM_FLOATS, 1, 3.0,
-
-          JVST_OP_PROC, VMLIT(1), VMLIT(0),
+          JVST_OP_PROC, VMLIT(0), VMLIT(0),
           JVST_OP_TOKEN, 0, 0,
           JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_NUMBER),
           JVST_OP_CBT, "true_2",
@@ -1036,8 +1222,7 @@ static void test_op_multiple_of(void)
           JVST_OP_VALID, 0, 0,
 
           VM_LABEL, "true_2",
-          JVST_OP_FLOAD, VMSLOT(0), VMLIT(0),
-          JVST_OP_FINT, VMREG(JVST_VM_TNUM), VMSLOT(0),
+          JVST_OP_FINT, VMREG(JVST_VM_TNUM), VMLIT(3),
           JVST_OP_CBT, "true_4",
 
           JVST_OP_INVALID, VMLIT(17), 0,
@@ -1051,7 +1236,6 @@ static void test_op_multiple_of(void)
 
           VM_END)
     },
-
     { STOP },
   };
 

--- a/tests/unit/validate_testing.c
+++ b/tests/unit/validate_testing.c
@@ -408,6 +408,12 @@ newschema_p(struct arena_info *A, int types, ...)
 				continue;
 			}
 			*vpp = vset;
+		} else if (strcmp(pname, "multipleOf") == 0) {
+			double divisor;
+
+			divisor = va_arg(args, double);
+			s->multiple_of = divisor;
+			s->kws |= KWS_MULTIPLE_OF;
 		} else {
 			// okay to abort() a test if the test writer forgot to add a
 			// property to the big dumb if-else chain
@@ -852,11 +858,21 @@ newcnode_propnames(struct arena_info *A, struct jvst_cnode *tree)
 struct jvst_cnode *
 newcnode_range(struct arena_info *A, enum jvst_cnode_rangeflags flags, double min, double max)
 {
-	struct jvst_cnode *node, **pp;
+	struct jvst_cnode *node;
 	node = newcnode(A, JVST_CNODE_NUM_RANGE);
 	node->u.num_range.flags = flags;
 	node->u.num_range.min   = min;
 	node->u.num_range.max   = max;
+	return node;
+}
+
+struct jvst_cnode *
+newcnode_multiple_of(struct arena_info *A, double divisor)
+{
+	struct jvst_cnode *node;
+	node = newcnode(A, JVST_CNODE_NUM_MULTIPLE_OF);
+	node->u.multiple_of = divisor;
+
 	return node;
 }
 
@@ -1614,6 +1630,16 @@ newir_isint(struct arena_info *A, struct jvst_ir_expr *arg)
 }
 
 struct jvst_ir_expr *
+newir_multiple_of(struct arena_info *A, struct jvst_ir_expr *arg, double divisor)
+{
+	struct jvst_ir_expr *expr;
+	expr = newir_expr(A,JVST_IR_EXPR_MULTIPLE_OF);
+	expr->u.multiple_of.arg = arg;
+	expr->u.multiple_of.divisor = divisor;
+	return expr;
+}
+
+struct jvst_ir_expr *
 newir_num(struct arena_info *A, double num)
 {
 	struct jvst_ir_expr *expr;
@@ -1827,6 +1853,7 @@ newir_op(struct arena_info *A, enum jvst_ir_expr_type op,
 	case JVST_IR_EXPR_BCOUNT:
 	case JVST_IR_EXPR_ISTOK:
 	case JVST_IR_EXPR_ISINT:
+	case JVST_IR_EXPR_MULTIPLE_OF:
 	case JVST_IR_EXPR_NOT:
 	case JVST_IR_EXPR_SPLIT:
 	case JVST_IR_EXPR_SLOT:

--- a/tests/unit/validate_testing.h
+++ b/tests/unit/validate_testing.h
@@ -135,6 +135,9 @@ struct jvst_cnode *
 newcnode_range(struct arena_info *A, enum jvst_cnode_rangeflags flags, double min, double max);
 
 struct jvst_cnode *
+newcnode_multiple_of(struct arena_info *A, double divisor);
+
+struct jvst_cnode *
 newcnode_counts(struct arena_info *A, enum jvst_cnode_type type,
 	size_t min, size_t max, bool upper);
 
@@ -264,6 +267,9 @@ newir_istok(struct arena_info *A, enum SJP_EVENT tt);
 
 struct jvst_ir_expr *
 newir_isint(struct arena_info *A, struct jvst_ir_expr *arg);
+
+struct jvst_ir_expr *
+newir_multiple_of(struct arena_info *A, struct jvst_ir_expr *arg, double divisor);
 
 struct jvst_ir_expr *
 newir_op(struct arena_info *A, enum jvst_ir_expr_type op,


### PR DESCRIPTION
Adds multipleOf constraint.

This constraint was overlooked when I initially wrote the VM, and I didn't add a FMULT operation.  The current VM encoding only uses 5-bits for the instruction, and there are 32 instructions, so there didn't appear to be an easy way to add this without refactoring a bunch of VM stuff (see issues https://github.com/katef/jvst/issues/35 and https://github.com/katef/jvst/issues/36).  This refactoring is low priority relative to adding constraints and writing the bits to emit C.

Instead of refactoring the instruction set, I've modified the FINT opcode to take a second argument.  If the argument is 'none', then the FINT instruction directly returns if its first argument is an integer.  Otherwise the first argument is divided by the second and FINT tests if the result is an integer.  This concisely allows us to test multipleOf without getting too CISC-y.

We should revisit this when either https://github.com/katef/jvst/issues/35 or https://github.com/katef/jvst/issues/36 is closed.

