### PR TITLE
Turns off annoying “unused” warnings for parser.c

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -21,6 +21,10 @@ CFLAGS.${src} += -std=c99 -Wno-missing-field-initializers
 DFLAGS.${src} += -std=c99
 .endfor
 
+.for src in ${SRC:Msrc/parser.c}
+CFLAGS.${src} += -Wno-unused-parameter
+.endfor
+
 VALID_SRC += src/validate_sbuf.c
 VALID_SRC += src/validate.c
 VALID_SRC += src/validate_constraints.c


### PR DESCRIPTION
Almost all of the “unused” warnings are for parameters that sid passes along but aren’t used in all rules/actions.  It’s not always possible to add a “(void)var;” to suppress the warning, so this turns off these unimportant warnings for parser.c, which is generated by sid.
