### PR TITLE
Fixes codepoint counting

### DIFF
--- a/src/parser.act
+++ b/src/parser.act
@@ -351,7 +351,7 @@
 				break;
 
 			case SJP_TOK_NUMBER:
-				fprintf(stderr, "<NUMBER: %f>\n", t->dbl);
+				fprintf(stderr, "<NUMBER: %f>\n", t->extra.dbl);
 				break;
 
 			case SJP_TOK_EOS:
@@ -408,7 +408,7 @@
 	NUMBER: () -> (n :number) = @{
 		assert(act_state->t.type == @$NUMBER);
 
-		@n = act_state->t.dbl;
+		@n = act_state->t.extra.dbl;
 	@};
 
 	TRUE: () -> (v :bool) = @{

--- a/src/validate_vm.c
+++ b/src/validate_vm.c
@@ -669,9 +669,13 @@ load_slots_from_token(struct jvst_vm *vm, uint32_t fp)
 	vm->stack[fp+JVST_VM_TLEN].i = 0;
 
 	vm->stack[fp+JVST_VM_TT].i = vm->evt.type;
-	vm->stack[fp+JVST_VM_TLEN].i += vm->evt.n;
+	if (vm->evt.type == SJP_STRING) {
+		vm->stack[fp+JVST_VM_TLEN].i += vm->evt.extra.ncp;
+	} else {
+		vm->stack[fp+JVST_VM_TLEN].i += vm->evt.n;
+	}
 	if (vm->evt.type == SJP_NUMBER) {
-		vm->stack[fp+JVST_VM_TNUM].f = vm->evt.d;
+		vm->stack[fp+JVST_VM_TNUM].f = vm->evt.extra.d;
 	}
 }
 


### PR DESCRIPTION
Integrates patches from SJP to correctly count codepoints.  Within the
VM, string lengths (TLEN register) are now in codepoints.

NB: codepoints are only available when the full string token is parsed.