### PR TITLE
Cleans up the VM instruction set

### DIFF
--- a/src/validate_vm.c
+++ b/src/validate_vm.c
@@ -39,22 +39,10 @@ jvst_op_name(enum jvst_vm_op op)
 	switch (op) {
 	case JVST_OP_NOP:	return "NOP";
 	case JVST_OP_PROC:	return "PROC";
-	case JVST_OP_ILT:       return "ILT";
-	case JVST_OP_ILE:       return "ILE";
-	case JVST_OP_IEQ:       return "IEQ";
-	case JVST_OP_IGE:       return "IGE";
-	case JVST_OP_IGT:       return "IGT";
-	case JVST_OP_INEQ:      return "INEQ";
-	case JVST_OP_FLT:       return "FLT";
-	case JVST_OP_FLE:       return "FLE";
-	case JVST_OP_FEQ:       return "FEQ";
-	case JVST_OP_FGE:       return "FGE";
-	case JVST_OP_FGT:       return "FGT";
-	case JVST_OP_FNEQ:      return "FNEQ";
+	case JVST_OP_ICMP:      return "ICMP";
+	case JVST_OP_FCMP:      return "FCMP";
 	case JVST_OP_FINT:      return "FINT";
-	case JVST_OP_BR:        return "BR";
-	case JVST_OP_CBT:       return "CBT";
-	case JVST_OP_CBF:      	return "CBF";
+	case JVST_OP_JMP:       return "JMP";
 	case JVST_OP_CALL:      return "CALL";
 	case JVST_OP_SPLIT:     return "SPLIT";
 	case JVST_OP_SPLITV:    return "SPLITV";
@@ -72,6 +60,25 @@ jvst_op_name(enum jvst_vm_op op)
 
 	fprintf(stderr, "Unknown OP %d\n", op);
 	abort();
+}
+
+const char *
+jvst_vm_br_cond_name(enum jvst_vm_br_cond brc)
+{
+	switch (brc) {
+	case 0x00: return "NV";
+	case 0x01: return "LT";
+	case 0x02: return "GT";
+	case 0x03: return "NE";
+	case 0x04: return "EQ";
+	case 0x05: return "LE";
+	case 0x06: return "GE";
+	case 0x07: return "AL";
+	default:
+	   fprintf(stderr, "%s:%d (%s) invalid JMP argument 0x%02x\n",
+		   __FILE__, __LINE__, __func__, (unsigned int)brc);
+	   abort();
+	}
 }
 
 static const char *
@@ -128,8 +135,6 @@ static void
 vm_dump_opcode(struct sbuf *buf, uint32_t pc, uint32_t c, int indent)
 {
 	const char *opname;
-	uint32_t barg;
-	long br;
 	enum jvst_vm_op op;
 	uint16_t a,b;
 
@@ -139,14 +144,21 @@ vm_dump_opcode(struct sbuf *buf, uint32_t pc, uint32_t c, int indent)
 
 	opname = jvst_op_name(op);
 	switch (op) {
-	case JVST_OP_BR:
-	case JVST_OP_CBT:
-	case JVST_OP_CBF:
+	case JVST_OP_JMP:
 	case JVST_OP_CALL:
-		barg = jvst_vm_decode_barg(c);
-		br = jvst_vm_tobarg(barg);
-		sbuf_snprintf(buf, "%05" PRIu32 "\t0x%08" PRIx32 "\t%s\t%-5ld\n",
-			pc, c, opname, br);
+		{
+			enum jvst_vm_br_cond brc;
+			uint32_t barg;
+			long br;
+
+			barg = jvst_vm_decode_barg(c);
+			brc  = jvst_vm_decode_bcond(c);
+			br = jvst_vm_tobarg(barg);
+			sbuf_snprintf(buf, "%05" PRIu32 "\t0x%08" PRIx32 "\t%s\t%3s %-5ld\n",
+				pc, c, opname, 
+				op == JVST_OP_JMP ? jvst_vm_br_cond_name(brc) : "",
+				br);
+		}
 		break;
 
 	default:
@@ -605,7 +617,7 @@ vm_fvalptr(struct jvst_vm *vm, uint32_t fp, uint32_t arg)
 }
 
 static inline int
-iopdiff(struct jvst_vm *vm, uint32_t fp, uint32_t opcode)
+iopcmp(struct jvst_vm *vm, uint32_t fp, uint32_t opcode)
 {
 	uint32_t a,b;
 	int64_t va,vb;
@@ -616,11 +628,11 @@ iopdiff(struct jvst_vm *vm, uint32_t fp, uint32_t opcode)
 	va = vm_ival(vm, fp, a);
 	vb = vm_ival(vm, fp, b);
 
-	return va-vb;
+	return (va > vb) - (va < vb);
 }
 
 static inline int
-fopdiff(struct jvst_vm *vm, uint32_t fp, uint32_t opcode)
+fopcmp(struct jvst_vm *vm, uint32_t fp, uint32_t opcode)
 {
 	uint32_t a,b;
 	double va,vb;
@@ -631,14 +643,7 @@ fopdiff(struct jvst_vm *vm, uint32_t fp, uint32_t opcode)
 	va = vm_fvalptr(vm, fp, a)[0];
 	vb = vm_fvalptr(vm, fp, b)[0];
 
-	va -= vb;
-	if (va > 0) {
-		return 1;
-	} else if (va < 0) {
-		return -1;
-	} else {
-		return 0;
-	}
+	return (va > vb) - (va < vb);
 }
 
 static inline int
@@ -1195,53 +1200,13 @@ loop:
 		NEXT;
 
 	/* integer comparisons */
-	case JVST_OP_ILT:
-		vm->r_flag = flag = iopdiff(vm, fp, opcode) < 0;
-		NEXT;
-
-	case JVST_OP_ILE:
-		vm->r_flag = flag = iopdiff(vm, fp, opcode) <= 0;
-		NEXT;
-
-	case JVST_OP_IEQ:
-		vm->r_flag = flag = iopdiff(vm, fp, opcode) == 0;
-		NEXT;
-
-	case JVST_OP_IGE:
-		vm->r_flag = flag = iopdiff(vm, fp, opcode) >= 0;
-		NEXT;
-
-	case JVST_OP_IGT:
-		vm->r_flag = flag = iopdiff(vm, fp, opcode) > 0;
-		NEXT;
-
-	case JVST_OP_INEQ:
-		vm->r_flag = flag = iopdiff(vm, fp, opcode) != 0;
+	case JVST_OP_ICMP:
+		vm->r_flag = flag = iopcmp(vm, fp, opcode);
 		NEXT;
 
 	/* floating point comparisons */
-	case JVST_OP_FLT:
-		vm->r_flag = flag = fopdiff(vm, fp, opcode) < 0;
-		NEXT;
-
-	case JVST_OP_FLE:
-		vm->r_flag = flag = fopdiff(vm, fp, opcode) <= 0;
-		NEXT;
-
-	case JVST_OP_FEQ:
-		vm->r_flag = flag = fopdiff(vm, fp, opcode) == 0;
-		NEXT;
-
-	case JVST_OP_FGE:
-		vm->r_flag = flag = fopdiff(vm, fp, opcode) >= 0;
-		NEXT;
-
-	case JVST_OP_FGT:
-		vm->r_flag = flag = fopdiff(vm, fp, opcode) > 0;
-		NEXT;
-
-	case JVST_OP_FNEQ:
-		vm->r_flag = flag = fopdiff(vm, fp, opcode) != 0;
+	case JVST_OP_FCMP:
+		vm->r_flag = flag = fopcmp(vm, fp, opcode);
 		NEXT;
 
 	case JVST_OP_FINT:
@@ -1271,18 +1236,25 @@ loop:
 		}
 		NEXT;
 
-	case JVST_OP_CBF:
-	case JVST_OP_CBT:
-		if (!!flag != (op == JVST_OP_CBT)) {
-			NEXT;
-		}
-
-		/* fallthrough */
-
-	case JVST_OP_BR:
+	case JVST_OP_JMP:
 		{
+			enum jvst_vm_br_cond brc;
 			uint32_t barg;
-			long br;
+			int fmask;
+
+			brc = jvst_vm_decode_bcond(opcode);
+			if (brc != JVST_VM_BR_ALWAYS) {
+				int mask;
+
+				// XXX - can we simplify / eliminate
+				// branches?
+				mask = (flag<0) | ((flag > 0) << 1) | ((flag == 0) << 2);
+
+				if ((brc & mask) == 0) {
+					NEXT;
+				}
+			}
+
 			barg = jvst_vm_decode_barg(opcode);
 			BRANCH(jvst_vm_tobarg(barg));
 		}

--- a/src/validate_vm.h
+++ b/src/validate_vm.h
@@ -72,12 +72,10 @@ enum jvst_vm_op {
 
 	JVST_OP_BAND,		// Bitwise-AND: BAND(regA,reg_slotB)  regA = regA & reg_slotB
 
-	JVST_OP_VALID,		// Consumes the current token and returns a VALID result for the current proc.
-				// If the current token in $OBJECT_BEG or $ARRAY_BEG, consumes the entire object/array.
-	JVST_OP_INVALID,	// Raises an INVALID result: INVALID(errcode)
+	JVST_OP_RETURN,		// Returns VALID or raises an INVALID result.  INVALID results have an error code.
 };
 
-#define JVST_OP_MAX JVST_OP_INVALID
+#define JVST_OP_MAX JVST_OP_RETURN
 
 /* VM opcode encoding:
  * 

--- a/tests/unit/test_op.c
+++ b/tests/unit/test_op.c
@@ -266,12 +266,12 @@ test_op_empty_schema(void)
           newop_proc(&A,
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_3"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_3"),
 
             oplabel, "false_4",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_3"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_3"),
 
             oplabel, "false_7",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -313,12 +313,12 @@ test_op_empty_schema(void)
           newop_proc(&A,
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_3"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_3"),
 
             oplabel, "false_4",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_3"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_3"),
 
             oplabel, "false_7",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -338,10 +338,10 @@ test_op_empty_schema(void)
       newvm_program(&A,
           JVST_OP_PROC, VMLIT(0), VMLIT(0),
           JVST_OP_TOKEN, 0, 0,
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_END),
-          JVST_OP_CBT, "invalid_1_3",
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_ARRAY_END),
-          JVST_OP_CBT, "invalid_1_3",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_END),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "invalid_1_3",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_ARRAY_END),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "invalid_1_3",
           JVST_OP_CONSUME, 0, 0,
           JVST_OP_RETURN, 0, 0,
           VM_LABEL, "invalid_1_3",
@@ -381,8 +381,8 @@ static void test_op_type_constraints(void)
           newop_proc(&A,
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_NUMBER)),
-            newop_br(&A, JVST_OP_CBT, "true_2"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_NUMBER)),
+            newop_br(&A, JVST_VM_BR_EQ, "true_2"),
 
             oplabel, "invalid_1_5",
             newop_return(&A, 1),
@@ -422,8 +422,8 @@ static void test_op_type_constraints(void)
           newop_proc(&A,
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
-            newop_br(&A, JVST_OP_CBT, "true_2"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
+            newop_br(&A, JVST_VM_BR_EQ, "true_2"),
 
             oplabel, "invalid_1_5",
             newop_return(&A, 1),
@@ -473,12 +473,12 @@ static void test_op_type_constraints(void)
           newop_proc(&A,
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_STRING)),
-            newop_br(&A, JVST_OP_CBT, "true_2"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_STRING)),
+            newop_br(&A, JVST_VM_BR_EQ, "true_2"),
 
             oplabel, "false_4",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
-            newop_br(&A, JVST_OP_CBT, "true_6"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
+            newop_br(&A, JVST_VM_BR_EQ, "true_6"),
 
             oplabel, "invalid_1_8",
             newop_return(&A, 1),
@@ -491,7 +491,7 @@ static void test_op_type_constraints(void)
 
             oplabel, "true_6",
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "valid_3"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "valid_3"),
 
             NULL
           ),
@@ -541,15 +541,15 @@ static void test_op_type_integer(void)
           newop_proc(&A,
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_NUMBER)),
-            newop_br(&A, JVST_OP_CBT, "true_2"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_NUMBER)),
+            newop_br(&A, JVST_VM_BR_EQ, "true_2"),
 
             oplabel, "invalid_1_9",
             newop_return(&A, 1),
 
             oplabel, "true_2",
             newop_cmp(&A, JVST_OP_FINT, oparg_tnum(), oparg_none()),
-            newop_br(&A, JVST_OP_CBT, "true_4"),
+            newop_br(&A, JVST_VM_BR_NE, "true_4"),
 
             oplabel, "invalid_2_7",
             newop_return(&A, 2),
@@ -590,15 +590,15 @@ static void test_op_type_integer(void)
           newop_proc(&A,
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_NUMBER)),
-            newop_br(&A, JVST_OP_CBT, "true_2"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_NUMBER)),
+            newop_br(&A, JVST_VM_BR_EQ, "true_2"),
 
             oplabel, "invalid_1_9",
             newop_return(&A, 1),
 
             oplabel, "true_2",
             newop_cmp(&A, JVST_OP_FINT, oparg_tnum(), oparg_none()),
-            newop_br(&A, JVST_OP_CBT, "valid_5"),
+            newop_br(&A, JVST_VM_BR_NE, "valid_5"),
 
             oplabel, "invalid_2_7",
             newop_return(&A, 2),
@@ -618,13 +618,13 @@ static void test_op_type_integer(void)
       newvm_program(&A,
           JVST_OP_PROC, VMLIT(0), VMLIT(0),
           JVST_OP_TOKEN, 0, 0,
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_NUMBER),
-          JVST_OP_CBT, "true_2",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_NUMBER),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "true_2",
           JVST_OP_RETURN, VMLIT(1), 0,
 
           VM_LABEL, "true_2",
           JVST_OP_FINT, VMREG(JVST_VM_TNUM), VMLIT(0),
-          JVST_OP_CBT, "true_4",
+          JVST_OP_JMP, JVST_VM_BR_NE, "true_4",
 
           JVST_OP_RETURN, VMLIT(2), 0,
 
@@ -682,8 +682,8 @@ static void test_op_minimum(void)
 
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_NUMBER)),
-            newop_br(&A, JVST_OP_CBT, "true_2"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_NUMBER)),
+            newop_br(&A, JVST_VM_BR_EQ, "true_2"),
 
             oplabel, "invalid_1_9",
             newop_return(&A, 1),
@@ -691,8 +691,8 @@ static void test_op_minimum(void)
             oplabel, "true_2",
             newop_load(&A, JVST_OP_MOVE, oparg_slot(1), oparg_tnum()),
             newop_load(&A, JVST_OP_FLOAD, oparg_slot(0), oparg_lit(0)),
-            newop_cmp(&A, JVST_OP_FGE, oparg_slot(1), oparg_slot(0)),
-            newop_br(&A, JVST_OP_CBT, "true_4"),
+            newop_cmp(&A, JVST_OP_FCMP, oparg_slot(1), oparg_slot(0)),
+            newop_br(&A, JVST_VM_BR_GE, "true_4"),
 
             oplabel, "invalid_3_7",
             newop_return(&A, 3),
@@ -777,8 +777,8 @@ static void test_op_minimum(void)
 
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_NUMBER)),
-            newop_br(&A, JVST_OP_CBT, "true_2"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_NUMBER)),
+            newop_br(&A, JVST_VM_BR_EQ, "true_2"),
 
             oplabel, "invalid_1_9",
             newop_return(&A, 1),
@@ -786,8 +786,8 @@ static void test_op_minimum(void)
             oplabel, "true_2",
             newop_load(&A, JVST_OP_MOVE, oparg_slot(1), oparg_tnum()),
             newop_load(&A, JVST_OP_FLOAD, oparg_slot(0), oparg_lit(0)),
-            newop_cmp(&A, JVST_OP_FGE, oparg_slot(1), oparg_slot(0)),
-            newop_br(&A, JVST_OP_CBT, "true_4"),
+            newop_cmp(&A, JVST_OP_FCMP, oparg_slot(1), oparg_slot(0)),
+            newop_br(&A, JVST_VM_BR_GE, "true_4"),
 
             oplabel, "invalid_3_7",
             newop_return(&A, 3),
@@ -809,15 +809,15 @@ static void test_op_minimum(void)
 
           JVST_OP_PROC, VMLIT(2), VMLIT(0),
           JVST_OP_TOKEN, 0, 0,
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_NUMBER),
-          JVST_OP_CBT, "true_2",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_NUMBER),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "true_2",
           JVST_OP_RETURN, VMLIT(1), 0,
 
           VM_LABEL, "true_2",
           JVST_OP_MOVE, VMSLOT(1), VMREG(JVST_VM_TNUM),
           JVST_OP_FLOAD, VMSLOT(0), VMLIT(0),
-          JVST_OP_FGE, VMSLOT(1), VMSLOT(0),
-          JVST_OP_CBT, "true_4",
+          JVST_OP_FCMP, VMSLOT(1), VMSLOT(0),
+          JVST_OP_JMP, JVST_VM_BR_GE, "true_4",
 
           JVST_OP_RETURN, VMLIT(3), 0,
 
@@ -880,16 +880,16 @@ static void test_op_multiple_of(void)
 
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_NUMBER)),
-            newop_br(&A, JVST_OP_CBT, "true_2"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_NUMBER)),
+            newop_br(&A, JVST_VM_BR_EQ, "true_2"),
 
             oplabel, "false_8",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_11"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_11"),
 
             oplabel, "false_12",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_11"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_11"),
 
             oplabel, "false_15",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -900,14 +900,14 @@ static void test_op_multiple_of(void)
             oplabel, "true_2",
             newop_load(&A, JVST_OP_FLOAD, oparg_slot(0), oparg_lit(0)),
             newop_cmp(&A, JVST_OP_FINT, oparg_tnum(), oparg_slot(0)),
-            newop_br(&A, JVST_OP_CBT, "true_4"),
+            newop_br(&A, JVST_VM_BR_NE, "true_4"),
 
             oplabel, "invalid_17_7",
             newop_return(&A, 17),
 
             oplabel, "true_4",
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "valid_5"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "valid_5"),
 
             oplabel, "invalid_1_11",
             newop_return(&A, 1),
@@ -960,16 +960,16 @@ static void test_op_multiple_of(void)
 
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_NUMBER)),
-            newop_br(&A, JVST_OP_CBT, "true_2"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_NUMBER)),
+            newop_br(&A, JVST_VM_BR_EQ, "true_2"),
 
             oplabel, "false_8",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_11"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_11"),
 
             oplabel, "false_12",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_11"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_11"),
 
             oplabel, "false_15",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -980,14 +980,14 @@ static void test_op_multiple_of(void)
             oplabel, "true_2",
             newop_load(&A, JVST_OP_FLOAD, oparg_slot(0), oparg_lit(0)),
             newop_cmp(&A, JVST_OP_FINT, oparg_tnum(), oparg_slot(0)),
-            newop_br(&A, JVST_OP_CBT, "true_4"),
+            newop_br(&A, JVST_VM_BR_NE, "true_4"),
 
             oplabel, "invalid_17_7",
             newop_return(&A, 17),
 
             oplabel, "true_4",
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "valid_5"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "valid_5"),
 
             oplabel, "invalid_1_11",
             newop_return(&A, 1),
@@ -1003,16 +1003,16 @@ static void test_op_multiple_of(void)
 
           JVST_OP_PROC, VMLIT(1), VMLIT(0),
           JVST_OP_TOKEN, 0, 0,
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_NUMBER),
-          JVST_OP_CBT, "true_2",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_NUMBER),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "true_2",
 
           VM_LABEL, "false_8",
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_END),
-          JVST_OP_CBT, "invalid_1_11",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_END),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "invalid_1_11",
 
           VM_LABEL, "false_12",
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_ARRAY_END),
-          JVST_OP_CBT, "invalid_1_11",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_ARRAY_END),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "invalid_1_11",
 
           VM_LABEL, "false_15",
           JVST_OP_CONSUME, 0, 0,
@@ -1023,13 +1023,13 @@ static void test_op_multiple_of(void)
           VM_LABEL, "true_2",
           JVST_OP_FLOAD, VMSLOT(0), VMLIT(0),
           JVST_OP_FINT, VMREG(JVST_VM_TNUM), VMSLOT(0),
-          JVST_OP_CBT, "true_4",
+          JVST_OP_JMP, JVST_VM_BR_NE, "true_4",
 
           JVST_OP_RETURN, VMLIT(17), 0,
 
           VM_LABEL, "true_4",
           JVST_OP_CONSUME, 0, 0,
-          JVST_OP_BR, "valid_5",
+          JVST_OP_JMP, JVST_VM_BR_ALWAYS, "valid_5",
 
           VM_LABEL, "invalid_1_11",
           JVST_OP_RETURN, VMLIT(1), 0,
@@ -1073,16 +1073,16 @@ static void test_op_multiple_of(void)
           newop_proc(&A,
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_NUMBER)),
-            newop_br(&A, JVST_OP_CBT, "true_2"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_NUMBER)),
+            newop_br(&A, JVST_VM_BR_EQ, "true_2"),
 
             oplabel, "false_8",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_11"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_11"),
 
             oplabel, "false_12",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_11"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_11"),
 
             oplabel, "false_15",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -1092,14 +1092,14 @@ static void test_op_multiple_of(void)
 
             oplabel, "true_2",
             newop_cmp(&A, JVST_OP_FINT, oparg_tnum(), oparg_lit(3)),
-            newop_br(&A, JVST_OP_CBT, "true_4"),
+            newop_br(&A, JVST_VM_BR_NE, "true_4"),
 
             oplabel, "invalid_17_7",
             newop_return(&A, 17),
 
             oplabel, "true_4",
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "valid_5"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "valid_5"),
 
             oplabel, "invalid_1_11",
             newop_return(&A, 1),
@@ -1148,16 +1148,16 @@ static void test_op_multiple_of(void)
           newop_proc(&A,
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_NUMBER)),
-            newop_br(&A, JVST_OP_CBT, "true_2"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_NUMBER)),
+            newop_br(&A, JVST_VM_BR_EQ, "true_2"),
 
             oplabel, "false_8",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_11"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_11"),
 
             oplabel, "false_12",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_11"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_11"),
 
             oplabel, "false_15",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -1168,14 +1168,14 @@ static void test_op_multiple_of(void)
             oplabel, "true_2",
             newop_load(&A, JVST_OP_FLOAD, oparg_slot(0), oparg_lit(0)),
             newop_cmp(&A, JVST_OP_FINT, oparg_tnum(), oparg_slot(0)),
-            newop_br(&A, JVST_OP_CBT, "true_4"),
+            newop_br(&A, JVST_VM_BR_EQ, "true_4"),
 
             oplabel, "invalid_17_7",
             newop_return(&A, 17),
 
             oplabel, "true_4",
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "valid_5"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "valid_5"),
 
             oplabel, "invalid_1_11",
             newop_return(&A, 1),
@@ -1189,16 +1189,16 @@ static void test_op_multiple_of(void)
       newvm_program(&A,
           JVST_OP_PROC, VMLIT(0), VMLIT(0),
           JVST_OP_TOKEN, 0, 0,
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_NUMBER),
-          JVST_OP_CBT, "true_2",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_NUMBER),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "true_2",
 
           VM_LABEL, "false_8",
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_END),
-          JVST_OP_CBT, "invalid_1_11",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_END),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "invalid_1_11",
 
           VM_LABEL, "false_12",
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_ARRAY_END),
-          JVST_OP_CBT, "invalid_1_11",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_ARRAY_END),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "invalid_1_11",
 
           VM_LABEL, "false_15",
           JVST_OP_CONSUME, 0, 0,
@@ -1208,13 +1208,13 @@ static void test_op_multiple_of(void)
 
           VM_LABEL, "true_2",
           JVST_OP_FINT, VMREG(JVST_VM_TNUM), VMLIT(3),
-          JVST_OP_CBT, "true_4",
+          JVST_OP_JMP, JVST_VM_BR_NE, "true_4",
 
           JVST_OP_RETURN, VMLIT(17), 0,
 
           VM_LABEL, "true_4",
           JVST_OP_CONSUME, 0, 0,
-          JVST_OP_BR, "valid_5",
+          JVST_OP_JMP, JVST_VM_BR_ALWAYS, "valid_5",
 
           VM_LABEL, "invalid_1_11",
           JVST_OP_RETURN, VMLIT(1), 0,
@@ -1330,16 +1330,16 @@ static void test_op_properties(void)
 
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
-            newop_br(&A, JVST_OP_CBT, "loop_4"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
+            newop_br(&A, JVST_VM_BR_EQ, "loop_4"),
 
             oplabel, "false_16",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_19"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_19"),
 
             oplabel, "false_20",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_19"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_19"),
 
             oplabel, "false_23",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -1349,37 +1349,37 @@ static void test_op_properties(void)
 
             oplabel, "loop_4",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "valid_15"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "valid_15"),
 
             oplabel, "false_7",
             newop_match(&A, 0),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(0), oparg_m()),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(0), oparg_lit(0)),
-            newop_br(&A, JVST_OP_CBT, "M_9"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(0), oparg_lit(0)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_9"),
 
             oplabel, "M_next_10",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(0), oparg_lit(1)),
-            newop_br(&A, JVST_OP_CBT, "M_11"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(0), oparg_lit(1)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_11"),
 
             oplabel, "M_next_12",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(0), oparg_lit(2)),
-            newop_br(&A, JVST_OP_CBT, "M_13"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(0), oparg_lit(2)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_13"),
 
             oplabel, "invalid_9_14",
             newop_return(&A, 9),
 
             oplabel, "M_9",
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "loop_4"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_4"),
 
             oplabel, "M_11",
             newop_call(&A, oparg_lit(1)),
-            newop_br(&A, JVST_OP_BR, "loop_4"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_4"),
 
             oplabel, "M_13",
             newop_call(&A, oparg_lit(2)),
-            newop_br(&A, JVST_OP_BR, "loop_4"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_4"),
 
             oplabel, "invalid_1_19",
             newop_return(&A, 1),
@@ -1390,8 +1390,8 @@ static void test_op_properties(void)
           newop_proc(&A,
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_STRING)),
-            newop_br(&A, JVST_OP_CBT, "true_2"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_STRING)),
+            newop_br(&A, JVST_VM_BR_EQ, "true_2"),
 
             oplabel, "invalid_1_5",
             newop_return(&A, 1),
@@ -1408,8 +1408,8 @@ static void test_op_properties(void)
           newop_proc(&A,
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_NUMBER)),
-            newop_br(&A, JVST_OP_CBT, "true_2"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_NUMBER)),
+            newop_br(&A, JVST_VM_BR_EQ, "true_2"),
 
             oplabel, "invalid_1_5",
             newop_return(&A, 1),
@@ -1524,16 +1524,16 @@ static void test_op_properties(void)
 
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
-            newop_br(&A, JVST_OP_CBT, "loop_4"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
+            newop_br(&A, JVST_VM_BR_EQ, "loop_4"),
 
             oplabel, "false_16",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_19"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_19"),
 
             oplabel, "false_20",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_19"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_19"),
 
             oplabel, "false_23",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -1543,37 +1543,37 @@ static void test_op_properties(void)
 
             oplabel, "loop_4",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "valid_15"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "valid_15"),
 
             oplabel, "false_7",
             newop_match(&A, 0),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(0), oparg_m()),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(0), oparg_lit(0)),
-            newop_br(&A, JVST_OP_CBT, "M_9"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(0), oparg_lit(0)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_9"),
 
             oplabel, "M_next_10",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(0), oparg_lit(1)),
-            newop_br(&A, JVST_OP_CBT, "M_11"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(0), oparg_lit(1)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_11"),
 
             oplabel, "M_next_12",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(0), oparg_lit(2)),
-            newop_br(&A, JVST_OP_CBT, "M_13"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(0), oparg_lit(2)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_13"),
 
             oplabel, "invalid_9_14",
             newop_return(&A, 9),
 
             oplabel, "M_9",
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "loop_4"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_4"),
 
             oplabel, "M_11",
             newop_call(&A, oparg_lit(1)),
-            newop_br(&A, JVST_OP_BR, "loop_4"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_4"),
 
             oplabel, "M_13",
             newop_call(&A, oparg_lit(2)),
-            newop_br(&A, JVST_OP_BR, "loop_4"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_4"),
 
             oplabel, "invalid_1_19",
             newop_return(&A, 1),
@@ -1584,8 +1584,8 @@ static void test_op_properties(void)
           newop_proc(&A,
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_STRING)),
-            newop_br(&A, JVST_OP_CBT, "true_2"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_STRING)),
+            newop_br(&A, JVST_VM_BR_EQ, "true_2"),
 
             oplabel, "invalid_1_5",
             newop_return(&A, 1),
@@ -1602,8 +1602,8 @@ static void test_op_properties(void)
           newop_proc(&A,
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_NUMBER)),
-            newop_br(&A, JVST_OP_CBT, "true_2"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_NUMBER)),
+            newop_br(&A, JVST_VM_BR_EQ, "true_2"),
 
             oplabel, "invalid_1_5",
             newop_return(&A, 1),
@@ -1625,14 +1625,14 @@ static void test_op_properties(void)
 
           JVST_OP_PROC, VMLIT(1), VMLIT(0),
           JVST_OP_TOKEN, 0, 0,
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_BEG),
-          JVST_OP_CBT, "loop_4",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_BEG),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "loop_4",
 
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_END),
-          JVST_OP_CBT, "invalid_1_19",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_END),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "invalid_1_19",
 
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_ARRAY_END),
-          JVST_OP_CBT, "invalid_1_19",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_ARRAY_END),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "invalid_1_19",
 
           VM_LABEL, "false_23",
           JVST_OP_CONSUME, 0, 0,
@@ -1642,33 +1642,33 @@ static void test_op_properties(void)
 
           VM_LABEL, "loop_4",
           JVST_OP_TOKEN, 0, 0,
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_END),
-          JVST_OP_CBT, "valid_15",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_END),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "valid_15",
 
           JVST_OP_MATCH, VMLIT(0), 0,
           JVST_OP_MOVE, VMSLOT(0), VMREG(JVST_VM_M),
-          JVST_OP_IEQ, VMSLOT(0), VMLIT(0),
-          JVST_OP_CBT, "M_9",
+          JVST_OP_ICMP, VMSLOT(0), VMLIT(0),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "M_9",
 
-          JVST_OP_IEQ, VMSLOT(0), VMLIT(1),
-          JVST_OP_CBT, "M_11",
+          JVST_OP_ICMP, VMSLOT(0), VMLIT(1),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "M_11",
 
-          JVST_OP_IEQ, VMSLOT(0), VMLIT(2),
-          JVST_OP_CBT, "M_13",
+          JVST_OP_ICMP, VMSLOT(0), VMLIT(2),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "M_13",
 
           JVST_OP_RETURN, VMLIT(9), 0,
 
           VM_LABEL, "M_9",
           JVST_OP_CONSUME, 0, 0,
-          JVST_OP_BR, "loop_4",
+          JVST_OP_JMP, JVST_VM_BR_ALWAYS, "loop_4",
 
           VM_LABEL, "M_11",
           JVST_OP_CALL, 2,
-          JVST_OP_BR, "loop_4",
+          JVST_OP_JMP, JVST_VM_BR_ALWAYS, "loop_4",
 
           VM_LABEL, "M_13",
           JVST_OP_CALL, 3,
-          JVST_OP_BR, "loop_4",
+          JVST_OP_JMP, JVST_VM_BR_ALWAYS, "loop_4",
 
           VM_LABEL, "invalid_1_19",
           JVST_OP_RETURN, VMLIT(1), 0,
@@ -1676,8 +1676,8 @@ static void test_op_properties(void)
           JVST_OP_PROC, VMLIT(0), VMLIT(0),
 
           JVST_OP_TOKEN, 0, 0,
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_STRING),
-          JVST_OP_CBT, "true_2a",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_STRING),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "true_2a",
 
           JVST_OP_RETURN, VMLIT(1), 0,
 
@@ -1690,8 +1690,8 @@ static void test_op_properties(void)
           JVST_OP_PROC, VMLIT(0), VMLIT(0),
 
           JVST_OP_TOKEN, 0, 0,
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_NUMBER),
-          JVST_OP_CBT, "true_2b",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_NUMBER),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "true_2b",
 
           JVST_OP_RETURN, VMLIT(1), 0,
 
@@ -1784,16 +1784,16 @@ static void test_op_properties(void)
 
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
-            newop_br(&A, JVST_OP_CBT, "loop_4"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
+            newop_br(&A, JVST_VM_BR_EQ, "loop_4"),
 
             oplabel, "false_16",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_19"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_19"),
 
             oplabel, "false_20",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_19"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_19"),
 
             oplabel, "false_23",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -1803,37 +1803,37 @@ static void test_op_properties(void)
 
             oplabel, "loop_4",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "valid_15"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "valid_15"),
 
             oplabel, "false_7",
             newop_match(&A, 0),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(0), oparg_m()),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(0), oparg_lit(0)),
-            newop_br(&A, JVST_OP_CBT, "M_9"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(0), oparg_lit(0)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_9"),
 
             oplabel, "M_next_10",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(0), oparg_lit(1)),
-            newop_br(&A, JVST_OP_CBT, "M_11"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(0), oparg_lit(1)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_11"),
 
             oplabel, "M_next_12",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(0), oparg_lit(2)),
-            newop_br(&A, JVST_OP_CBT, "M_13"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(0), oparg_lit(2)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_13"),
 
             oplabel, "invalid_9_14",
             newop_return(&A, 9),
 
             oplabel, "M_9",
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "loop_4"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_4"),
 
             oplabel, "M_11",
             newop_call(&A, oparg_lit(1)),
-            newop_br(&A, JVST_OP_BR, "loop_4"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_4"),
 
             oplabel, "M_13",
             newop_call(&A, oparg_lit(2)),
-            newop_br(&A, JVST_OP_BR, "loop_4"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_4"),
 
             oplabel, "invalid_1_19",
             newop_return(&A, 1),
@@ -1854,8 +1854,8 @@ static void test_op_properties(void)
           newop_proc(&A,
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_NUMBER)),
-            newop_br(&A, JVST_OP_CBT, "true_2"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_NUMBER)),
+            newop_br(&A, JVST_VM_BR_EQ, "true_2"),
 
             oplabel, "invalid_1_5",
             newop_return(&A, 1),
@@ -1968,16 +1968,16 @@ void test_op_minmax_properties_1(void)
 
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
-            newop_br(&A, JVST_OP_CBT, "loop_4"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
+            newop_br(&A, JVST_VM_BR_EQ, "loop_4"),
 
             oplabel, "false_13",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_16"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_16"),
 
             oplabel, "false_17",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_16"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_16"),
 
             oplabel, "false_20",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -1987,21 +1987,21 @@ void test_op_minmax_properties_1(void)
 
             oplabel, "loop_4",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "loop_end_3"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "loop_end_3"),
 
             oplabel, "false_7",
             newop_instr(&A, JVST_OP_CONSUME),
             newop_instr(&A, JVST_OP_CONSUME),
             newop_incr(&A, 0),
-            newop_br(&A, JVST_OP_BR, "loop_4"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_4"),
 
             oplabel, "loop_end_3",
             newop_load(&A, JVST_OP_MOVE, oparg_slot(1), oparg_slot(0)),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(3), oparg_slot(1)),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(2), oparg_lit(1)),
-            newop_cmp(&A, JVST_OP_IGE, oparg_slot(3), oparg_slot(2)),
-            newop_br(&A, JVST_OP_CBT, "valid_10"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(3), oparg_slot(2)),
+            newop_br(&A, JVST_VM_BR_GE, "valid_10"),
 
             oplabel, "invalid_4_12",
             newop_return(&A, 4),
@@ -2083,16 +2083,16 @@ void test_op_minmax_properties_1(void)
 
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
-            newop_br(&A, JVST_OP_CBT, "loop_4"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
+            newop_br(&A, JVST_VM_BR_EQ, "loop_4"),
 
             oplabel, "false_13",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_16"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_16"),
 
             oplabel, "false_17",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_16"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_16"),
 
             oplabel, "false_20",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -2102,21 +2102,21 @@ void test_op_minmax_properties_1(void)
 
             oplabel, "loop_4",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "loop_end_3"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "loop_end_3"),
 
             oplabel, "false_7",
             newop_instr(&A, JVST_OP_CONSUME),
             newop_instr(&A, JVST_OP_CONSUME),
             newop_incr(&A, 0),
-            newop_br(&A, JVST_OP_BR, "loop_4"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_4"),
 
             oplabel, "loop_end_3",
             newop_load(&A, JVST_OP_MOVE, oparg_slot(1), oparg_slot(0)),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(3), oparg_slot(1)),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(2), oparg_lit(2)),
-            newop_cmp(&A, JVST_OP_ILE, oparg_slot(3), oparg_slot(2)),
-            newop_br(&A, JVST_OP_CBT, "valid_10"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(3), oparg_slot(2)),
+            newop_br(&A, JVST_VM_BR_LE, "valid_10"),
 
             oplabel, "invalid_5_12",
             newop_return(&A, 5),
@@ -2198,16 +2198,16 @@ void test_op_minmax_properties_1(void)
 
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
-            newop_br(&A, JVST_OP_CBT, "loop_4"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
+            newop_br(&A, JVST_VM_BR_EQ, "loop_4"),
 
             oplabel, "false_17",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_20"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_20"),
 
             oplabel, "false_21",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_20"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_20"),
 
             oplabel, "false_24",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -2217,21 +2217,21 @@ void test_op_minmax_properties_1(void)
 
             oplabel, "loop_4",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "loop_end_3"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "loop_end_3"),
 
             oplabel, "false_7",
             newop_instr(&A, JVST_OP_CONSUME),
             newop_instr(&A, JVST_OP_CONSUME),
             newop_incr(&A, 0),
-            newop_br(&A, JVST_OP_BR, "loop_4"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_4"),
 
             oplabel, "loop_end_3",
             newop_load(&A, JVST_OP_MOVE, oparg_slot(4), oparg_slot(0)),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(6), oparg_slot(4)),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(5), oparg_lit(2)),
-            newop_cmp(&A, JVST_OP_IGE, oparg_slot(6), oparg_slot(5)),
-            newop_br(&A, JVST_OP_CBT, "true_9"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(6), oparg_slot(5)),
+            newop_br(&A, JVST_VM_BR_GE, "true_9"),
 
             oplabel, "invalid_4_16",
             newop_return(&A, 4),
@@ -2240,8 +2240,8 @@ void test_op_minmax_properties_1(void)
             newop_load(&A, JVST_OP_MOVE, oparg_slot(1), oparg_slot(0)),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(3), oparg_slot(1)),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(2), oparg_lit(5)),
-            newop_cmp(&A, JVST_OP_ILE, oparg_slot(3), oparg_slot(2)),
-            newop_br(&A, JVST_OP_CBT, "valid_12"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(3), oparg_slot(2)),
+            newop_br(&A, JVST_VM_BR_LE, "valid_12"),
 
             oplabel, "invalid_5_14",
             newop_return(&A, 5),
@@ -2323,16 +2323,16 @@ void test_op_minmax_properties_1(void)
 
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
-            newop_br(&A, JVST_OP_CBT, "loop_4"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
+            newop_br(&A, JVST_VM_BR_EQ, "loop_4"),
 
             oplabel, "false_17",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_20"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_20"),
 
             oplabel, "false_21",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_20"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_20"),
 
             oplabel, "false_24",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -2342,21 +2342,21 @@ void test_op_minmax_properties_1(void)
 
             oplabel, "loop_4",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "loop_end_3"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "loop_end_3"),
 
             oplabel, "false_7",
             newop_instr(&A, JVST_OP_CONSUME),
             newop_instr(&A, JVST_OP_CONSUME),
             newop_incr(&A, 0),
-            newop_br(&A, JVST_OP_BR, "loop_4"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_4"),
 
             oplabel, "loop_end_3",
             newop_load(&A, JVST_OP_MOVE, oparg_slot(4), oparg_slot(0)),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(6), oparg_slot(4)),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(5), oparg_lit(2)),
-            newop_cmp(&A, JVST_OP_IGE, oparg_slot(6), oparg_slot(5)),
-            newop_br(&A, JVST_OP_CBT, "true_9"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(6), oparg_slot(5)),
+            newop_br(&A, JVST_VM_BR_GE, "true_9"),
 
             oplabel, "invalid_4_16",
             newop_return(&A, 4),
@@ -2365,8 +2365,8 @@ void test_op_minmax_properties_1(void)
             newop_load(&A, JVST_OP_MOVE, oparg_slot(1), oparg_slot(0)),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(3), oparg_slot(1)),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(2), oparg_lit(5)),
-            newop_cmp(&A, JVST_OP_ILE, oparg_slot(3), oparg_slot(2)),
-            newop_br(&A, JVST_OP_CBT, "valid_12"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(3), oparg_slot(2)),
+            newop_br(&A, JVST_VM_BR_LE, "valid_12"),
 
             oplabel, "invalid_5_14",
             newop_return(&A, 5),
@@ -2383,14 +2383,14 @@ void test_op_minmax_properties_1(void)
       newvm_program(&A,
           JVST_OP_PROC, VMLIT(7), VMLIT(0),
           JVST_OP_TOKEN, 0, 0,
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_BEG),
-          JVST_OP_CBT, "loop_4",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_BEG),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "loop_4",
 
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_END),
-          JVST_OP_CBT, "invalid_1_20",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_END),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "invalid_1_20",
 
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_ARRAY_END),
-          JVST_OP_CBT, "invalid_1_20",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_ARRAY_END),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "invalid_1_20",
 
           VM_LABEL, "false_24",
           JVST_OP_CONSUME, 0, 0,
@@ -2400,20 +2400,20 @@ void test_op_minmax_properties_1(void)
 
           VM_LABEL, "loop_4",
           JVST_OP_TOKEN, 0, 0,
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_END),
-          JVST_OP_CBT, "loop_end_3",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_END),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "loop_end_3",
 
           JVST_OP_CONSUME, 0, 0,
           JVST_OP_CONSUME, 0, 0,
           JVST_OP_INCR, VMSLOT(0), VMLIT(1),
-          JVST_OP_BR, "loop_4",
+          JVST_OP_JMP, JVST_VM_BR_ALWAYS, "loop_4",
 
           VM_LABEL, "loop_end_3",
           JVST_OP_MOVE, VMSLOT(4), VMSLOT(0),
           JVST_OP_MOVE, VMSLOT(6), VMSLOT(4),
           JVST_OP_MOVE, VMSLOT(5), VMLIT(2),
-          JVST_OP_IGE, VMSLOT(6), VMSLOT(5),
-          JVST_OP_CBT, "true_9",
+          JVST_OP_ICMP, VMSLOT(6), VMSLOT(5),
+          JVST_OP_JMP, JVST_VM_BR_GE, "true_9",
 
           JVST_OP_RETURN, VMLIT(4), 0,
 
@@ -2421,8 +2421,8 @@ void test_op_minmax_properties_1(void)
           JVST_OP_MOVE, VMSLOT(1), VMSLOT(0),
           JVST_OP_MOVE, VMSLOT(3), VMSLOT(1),
           JVST_OP_MOVE, VMSLOT(2), VMLIT(5),
-          JVST_OP_ILE, VMSLOT(3), VMSLOT(2),
-          JVST_OP_CBT, "valid_12",
+          JVST_OP_ICMP, VMSLOT(3), VMSLOT(2),
+          JVST_OP_JMP, JVST_VM_BR_LE, "valid_12",
 
           JVST_OP_RETURN, VMLIT(5), 0,
 
@@ -2555,16 +2555,16 @@ void test_op_minproperties_2(void)
 
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
-            newop_br(&A, JVST_OP_CBT, "loop_4"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
+            newop_br(&A, JVST_VM_BR_EQ, "loop_4"),
 
             oplabel, "false_20",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_23"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_23"),
 
             oplabel, "false_24",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_23"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_23"),
 
             oplabel, "false_27",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -2574,22 +2574,22 @@ void test_op_minproperties_2(void)
 
             oplabel, "loop_4",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "loop_end_3"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "loop_end_3"),
 
             oplabel, "false_7",
             newop_match(&A, 0),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(1), oparg_m()),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(1), oparg_lit(0)),
-            newop_br(&A, JVST_OP_CBT, "M_9"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(1), oparg_lit(0)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_9"),
 
             oplabel, "M_next_10",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(1), oparg_lit(1)),
-            newop_br(&A, JVST_OP_CBT, "M_11"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(1), oparg_lit(1)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_11"),
 
             oplabel, "M_next_12",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(1), oparg_lit(2)),
-            newop_br(&A, JVST_OP_CBT, "M_13"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(1), oparg_lit(2)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_13"),
 
             oplabel, "invalid_9_14",
             newop_return(&A, 9),
@@ -2599,22 +2599,22 @@ void test_op_minproperties_2(void)
 
             oplabel, "M_join_8",
             newop_incr(&A, 0),
-            newop_br(&A, JVST_OP_BR, "loop_4"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_4"),
 
             oplabel, "M_11",
             newop_call(&A, oparg_lit(1)),
-            newop_br(&A, JVST_OP_BR, "M_join_8"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "M_join_8"),
 
             oplabel, "M_13",
             newop_call(&A, oparg_lit(2)),
-            newop_br(&A, JVST_OP_BR, "M_join_8"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "M_join_8"),
 
             oplabel, "loop_end_3",
             newop_load(&A, JVST_OP_MOVE, oparg_slot(2), oparg_slot(0)),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(4), oparg_slot(2)),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(3), oparg_lit(1)),
-            newop_cmp(&A, JVST_OP_IGE, oparg_slot(4), oparg_slot(3)),
-            newop_br(&A, JVST_OP_CBT, "valid_17"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(4), oparg_slot(3)),
+            newop_br(&A, JVST_VM_BR_GE, "valid_17"),
 
             oplabel, "invalid_4_19",
             newop_return(&A, 4),
@@ -2628,8 +2628,8 @@ void test_op_minproperties_2(void)
           newop_proc(&A,
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_STRING)),
-            newop_br(&A, JVST_OP_CBT, "true_2"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_STRING)),
+            newop_br(&A, JVST_VM_BR_EQ, "true_2"),
 
             oplabel, "invalid_1_5",
             newop_return(&A, 1),
@@ -2646,8 +2646,8 @@ void test_op_minproperties_2(void)
           newop_proc(&A,
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_NUMBER)),
-            newop_br(&A, JVST_OP_CBT, "true_2"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_NUMBER)),
+            newop_br(&A, JVST_VM_BR_EQ, "true_2"),
 
             oplabel, "invalid_1_5",
             newop_return(&A, 1),
@@ -2800,16 +2800,16 @@ void test_op_required(void)
 
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
-            newop_br(&A, JVST_OP_CBT, "loop_4"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
+            newop_br(&A, JVST_VM_BR_EQ, "loop_4"),
 
             oplabel, "false_20",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_23"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_23"),
 
             oplabel, "false_24",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_23"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_23"),
 
             oplabel, "false_27",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -2819,44 +2819,44 @@ void test_op_required(void)
 
             oplabel, "loop_4",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "loop_end_3"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "loop_end_3"),
 
             oplabel, "false_7",
             newop_match(&A, 0),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(1), oparg_m()),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(1), oparg_lit(0)),
-            newop_br(&A, JVST_OP_CBT, "M_9"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(1), oparg_lit(0)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_9"),
 
             oplabel, "M_next_10",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(1), oparg_lit(1)),
-            newop_br(&A, JVST_OP_CBT, "M_11"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(1), oparg_lit(1)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_11"),
 
             oplabel, "M_next_12",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(1), oparg_lit(2)),
-            newop_br(&A, JVST_OP_CBT, "M_13"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(1), oparg_lit(2)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_13"),
 
             oplabel, "invalid_9_14",
             newop_return(&A, 9),
 
             oplabel, "M_9",
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "loop_4"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_4"),
 
             oplabel, "M_11",
             newop_call(&A, oparg_lit(1)),
-            newop_br(&A, JVST_OP_BR, "loop_4"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_4"),
 
             oplabel, "M_13",
             newop_call(&A, oparg_lit(2)),
             newop_bitop(&A, JVST_OP_BSET, 0, 0),
-            newop_br(&A, JVST_OP_BR, "loop_4"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_4"),
 
             oplabel, "loop_end_3",
             newop_load(&A, JVST_OP_MOVE, oparg_slot(2), oparg_slot(0)),
             newop_instr2(&A, JVST_OP_BAND, oparg_slot(2), oparg_lit(1)),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(2), oparg_lit(1)),
-            newop_br(&A, JVST_OP_CBT, "valid_17"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(2), oparg_lit(1)),
+            newop_br(&A, JVST_VM_BR_EQ, "valid_17"),
 
             oplabel, "invalid_6_19",
             newop_return(&A, 6),
@@ -2870,8 +2870,8 @@ void test_op_required(void)
           newop_proc(&A,
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_STRING)),
-            newop_br(&A, JVST_OP_CBT, "true_2"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_STRING)),
+            newop_br(&A, JVST_VM_BR_EQ, "true_2"),
 
             oplabel, "invalid_1_5",
             newop_return(&A, 1),
@@ -2888,8 +2888,8 @@ void test_op_required(void)
           newop_proc(&A,
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_NUMBER)),
-            newop_br(&A, JVST_OP_CBT, "true_2"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_NUMBER)),
+            newop_br(&A, JVST_VM_BR_EQ, "true_2"),
 
             oplabel, "invalid_1_5",
             newop_return(&A, 1),
@@ -3017,16 +3017,16 @@ void test_op_required(void)
 
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
-            newop_br(&A, JVST_OP_CBT, "loop_4"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
+            newop_br(&A, JVST_VM_BR_EQ, "loop_4"),
 
             oplabel, "false_20",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_23"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_23"),
 
             oplabel, "false_24",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_23"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_23"),
 
             oplabel, "false_27",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -3036,44 +3036,44 @@ void test_op_required(void)
 
             oplabel, "loop_4",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "loop_end_3"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "loop_end_3"),
 
             oplabel, "false_7",
             newop_match(&A, 0),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(1), oparg_m()),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(1), oparg_lit(0)),
-            newop_br(&A, JVST_OP_CBT, "M_9"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(1), oparg_lit(0)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_9"),
 
             oplabel, "M_next_10",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(1), oparg_lit(1)),
-            newop_br(&A, JVST_OP_CBT, "M_11"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(1), oparg_lit(1)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_11"),
 
             oplabel, "M_next_12",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(1), oparg_lit(2)),
-            newop_br(&A, JVST_OP_CBT, "M_13"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(1), oparg_lit(2)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_13"),
 
             oplabel, "invalid_9_14",
             newop_return(&A, 9),
 
             oplabel, "M_9",
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "loop_4"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_4"),
 
             oplabel, "M_11",
             newop_call(&A, oparg_lit(1)),
-            newop_br(&A, JVST_OP_BR, "loop_4"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_4"),
 
             oplabel, "M_13",
             newop_call(&A, oparg_lit(2)),
             newop_bitop(&A, JVST_OP_BSET, 0, 0),
-            newop_br(&A, JVST_OP_BR, "loop_4"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_4"),
 
             oplabel, "loop_end_3",
             newop_load(&A, JVST_OP_MOVE, oparg_slot(2), oparg_slot(0)),
             newop_instr2(&A, JVST_OP_BAND, oparg_slot(2), oparg_lit(1)),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(2), oparg_lit(1)),
-            newop_br(&A, JVST_OP_CBT, "valid_17"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(2), oparg_lit(1)),
+            newop_br(&A, JVST_VM_BR_EQ, "valid_17"),
 
             oplabel, "invalid_6_19",
             newop_return(&A, 6),
@@ -3087,8 +3087,8 @@ void test_op_required(void)
           newop_proc(&A,
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_STRING)),
-            newop_br(&A, JVST_OP_CBT, "true_2"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_STRING)),
+            newop_br(&A, JVST_VM_BR_EQ, "true_2"),
 
             oplabel, "invalid_1_5",
             newop_return(&A, 1),
@@ -3105,8 +3105,8 @@ void test_op_required(void)
           newop_proc(&A,
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_NUMBER)),
-            newop_br(&A, JVST_OP_CBT, "true_2"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_NUMBER)),
+            newop_br(&A, JVST_VM_BR_EQ, "true_2"),
 
             oplabel, "invalid_1_5",
             newop_return(&A, 1),
@@ -3128,14 +3128,14 @@ void test_op_required(void)
 
           JVST_OP_PROC, VMLIT(3), VMLIT(0),
           JVST_OP_TOKEN, 0, 0,
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_BEG),
-          JVST_OP_CBT, "loop_4",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_BEG),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "loop_4",
 
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_END),
-          JVST_OP_CBT, "invalid_1_23",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_END),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "invalid_1_23",
 
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_ARRAY_END),
-          JVST_OP_CBT, "invalid_1_23",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_ARRAY_END),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "invalid_1_23",
 
           VM_LABEL, "false_27",
           JVST_OP_CONSUME, 0, 0,
@@ -3145,40 +3145,40 @@ void test_op_required(void)
 
           VM_LABEL, "loop_4",
           JVST_OP_TOKEN, 0, 0,
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_END),
-          JVST_OP_CBT, "loop_end_3",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_END),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "loop_end_3",
 
           JVST_OP_MATCH, VMLIT(0), VMLIT(0),
           JVST_OP_MOVE, VMSLOT(1), VMREG(JVST_VM_M),
-          JVST_OP_IEQ, VMSLOT(1), VMLIT(0),
-          JVST_OP_CBT, "M_9",
+          JVST_OP_ICMP, VMSLOT(1), VMLIT(0),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "M_9",
 
-          JVST_OP_IEQ, VMSLOT(1), VMLIT(1),
-          JVST_OP_CBT, "M_11",
+          JVST_OP_ICMP, VMSLOT(1), VMLIT(1),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "M_11",
 
-          JVST_OP_IEQ, VMSLOT(1), VMLIT(2),
-          JVST_OP_CBT, "M_13",
+          JVST_OP_ICMP, VMSLOT(1), VMLIT(2),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "M_13",
 
           JVST_OP_RETURN, VMLIT(9), 0,
 
           VM_LABEL, "M_9",
           JVST_OP_CONSUME, VMLIT(0), VMLIT(0),
-          JVST_OP_BR, "loop_4",
+          JVST_OP_JMP, JVST_VM_BR_ALWAYS, "loop_4",
 
           VM_LABEL, "M_11",
           JVST_OP_CALL, 2,
-          JVST_OP_BR, "loop_4",
+          JVST_OP_JMP, JVST_VM_BR_ALWAYS, "loop_4",
 
           VM_LABEL, "M_13",
           JVST_OP_CALL, 3,
           JVST_OP_BSET, VMSLOT(0), VMLIT(0),
-          JVST_OP_BR, "loop_4",
+          JVST_OP_JMP, JVST_VM_BR_ALWAYS, "loop_4",
 
           VM_LABEL, "loop_end_3",
           JVST_OP_MOVE, VMSLOT(2), VMSLOT(0),
           JVST_OP_BAND, VMSLOT(2), VMLIT(1),
-          JVST_OP_IEQ, VMSLOT(2), VMLIT(1),
-          JVST_OP_CBT, "valid_17",
+          JVST_OP_ICMP, VMSLOT(2), VMLIT(1),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "valid_17",
 
           JVST_OP_RETURN, VMLIT(6), 0,
 
@@ -3188,8 +3188,8 @@ void test_op_required(void)
           JVST_OP_PROC, VMLIT(0), VMLIT(0),
 
           JVST_OP_TOKEN, 0, 0,
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_STRING),
-          JVST_OP_CBT, "true_2a",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_STRING),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "true_2a",
 
           JVST_OP_RETURN, VMLIT(1), 0,
 
@@ -3202,8 +3202,8 @@ void test_op_required(void)
           JVST_OP_PROC, VMLIT(0), VMLIT(0),
 
           JVST_OP_TOKEN, 0, 0,
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_NUMBER),
-          JVST_OP_CBT, "true_2b",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_NUMBER),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "true_2b",
 
           JVST_OP_RETURN, VMLIT(1), 0,
 
@@ -3366,16 +3366,16 @@ void test_op_dependencies(void)
 
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
-            newop_br(&A, JVST_OP_CBT, "true_2"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
+            newop_br(&A, JVST_VM_BR_EQ, "true_2"),
 
             oplabel, "false_8",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_11"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_11"),
 
             oplabel, "false_12",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_11"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_11"),
 
             oplabel, "false_15",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -3388,8 +3388,8 @@ void test_op_dependencies(void)
             newop_load(&A, JVST_OP_MOVE, oparg_slot(0), oparg_slot(3)),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(2), oparg_slot(0)),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(1), oparg_lit(1)),
-            newop_cmp(&A, JVST_OP_IGE, oparg_slot(2), oparg_slot(1)),
-            newop_br(&A, JVST_OP_CBT, "valid_5"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(2), oparg_slot(1)),
+            newop_br(&A, JVST_VM_BR_GE, "valid_5"),
 
             oplabel, "invalid_7_7",
             newop_return(&A, 7),
@@ -3405,25 +3405,25 @@ void test_op_dependencies(void)
 
             oplabel, "loop_2",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "valid_12"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "valid_12"),
 
             oplabel, "false_5",
             newop_match(&A, 0),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(0), oparg_m()),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(0), oparg_lit(0)),
-            newop_br(&A, JVST_OP_CBT, "M_7"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(0), oparg_lit(0)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_7"),
 
             oplabel, "M_next_8",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(0), oparg_lit(1)),
-            newop_br(&A, JVST_OP_CBT, "invalid_8_10"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(0), oparg_lit(1)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_8_10"),
 
             oplabel, "invalid_9_11",
             newop_return(&A, 9),
 
             oplabel, "M_7",
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "loop_2"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_2"),
 
             oplabel, "valid_12",
             newop_return(&A, 0),
@@ -3439,45 +3439,45 @@ void test_op_dependencies(void)
 
             oplabel, "loop_2",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "loop_end_1"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "loop_end_1"),
 
             oplabel, "false_5",
             newop_match(&A, 1),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(1), oparg_m()),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(1), oparg_lit(0)),
-            newop_br(&A, JVST_OP_CBT, "M_7"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(1), oparg_lit(0)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_7"),
 
             oplabel, "M_next_8",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(1), oparg_lit(1)),
-            newop_br(&A, JVST_OP_CBT, "M_9"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(1), oparg_lit(1)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_9"),
 
             oplabel, "M_next_10",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(1), oparg_lit(2)),
-            newop_br(&A, JVST_OP_CBT, "M_11"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(1), oparg_lit(2)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_11"),
 
             oplabel, "invalid_9_12",
             newop_return(&A, 9),
 
             oplabel, "M_7",
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "loop_2"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_2"),
 
             oplabel, "M_9",
             newop_bitop(&A, JVST_OP_BSET, 0, 0),
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "loop_2"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_2"),
 
             oplabel, "M_11",
             newop_bitop(&A, JVST_OP_BSET, 0, 1),
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "loop_2"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_2"),
 
             oplabel, "loop_end_1",
             newop_load(&A, JVST_OP_MOVE, oparg_slot(2), oparg_slot(0)),
             newop_instr2(&A, JVST_OP_BAND, oparg_slot(2), oparg_lit(3)),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(2), oparg_lit(3)),
-            newop_br(&A, JVST_OP_CBT, "valid_15"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(2), oparg_lit(3)),
+            newop_br(&A, JVST_VM_BR_EQ, "valid_15"),
 
             oplabel, "invalid_6_17",
             newop_return(&A, 6),
@@ -3626,16 +3626,16 @@ void test_op_dependencies(void)
 
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
-            newop_br(&A, JVST_OP_CBT, "true_2"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
+            newop_br(&A, JVST_VM_BR_EQ, "true_2"),
 
             oplabel, "false_8",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_11"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_11"),
 
             oplabel, "false_12",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_11"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_11"),
 
             oplabel, "valid_5",
             newop_return(&A, 0),
@@ -3645,8 +3645,8 @@ void test_op_dependencies(void)
             newop_load(&A, JVST_OP_MOVE, oparg_slot(0), oparg_slot(3)),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(2), oparg_slot(0)),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(1), oparg_lit(1)),
-            newop_cmp(&A, JVST_OP_IGE, oparg_slot(2), oparg_slot(1)),
-            newop_br(&A, JVST_OP_CBT, "valid_5"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(2), oparg_slot(1)),
+            newop_br(&A, JVST_VM_BR_GE, "valid_5"),
 
             oplabel, "invalid_7_7",
             newop_return(&A, 7),
@@ -3662,25 +3662,25 @@ void test_op_dependencies(void)
 
             oplabel, "loop_2",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "valid_12"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "valid_12"),
 
             oplabel, "false_5",
             newop_match(&A, 0),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(0), oparg_m()),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(0), oparg_lit(0)),
-            newop_br(&A, JVST_OP_CBT, "M_7"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(0), oparg_lit(0)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_7"),
 
             oplabel, "M_next_8",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(0), oparg_lit(1)),
-            newop_br(&A, JVST_OP_CBT, "invalid_8_10"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(0), oparg_lit(1)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_8_10"),
 
             oplabel, "invalid_9_11",
             newop_return(&A, 9),
 
             oplabel, "M_7",
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "loop_2"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_2"),
 
             oplabel, "valid_12",
             newop_return(&A, 0),
@@ -3696,45 +3696,45 @@ void test_op_dependencies(void)
 
             oplabel, "loop_2",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "loop_end_1"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "loop_end_1"),
 
             oplabel, "false_5",
             newop_match(&A, 1),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(1), oparg_m()),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(1), oparg_lit(0)),
-            newop_br(&A, JVST_OP_CBT, "M_7"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(1), oparg_lit(0)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_7"),
 
             oplabel, "M_next_8",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(1), oparg_lit(1)),
-            newop_br(&A, JVST_OP_CBT, "M_9"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(1), oparg_lit(1)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_9"),
 
             oplabel, "M_next_10",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(1), oparg_lit(2)),
-            newop_br(&A, JVST_OP_CBT, "M_11"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(1), oparg_lit(2)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_11"),
 
             oplabel, "invalid_9_12",
             newop_return(&A, 9),
 
             oplabel, "M_7",
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "loop_2"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_2"),
 
             oplabel, "M_9",
             newop_bitop(&A, JVST_OP_BSET, 0, 0),
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "loop_2"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_2"),
 
             oplabel, "M_11",
             newop_bitop(&A, JVST_OP_BSET, 0, 1),
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "loop_2"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_2"),
 
             oplabel, "loop_end_1",
             newop_load(&A, JVST_OP_MOVE, oparg_slot(2), oparg_slot(0)),
             newop_instr2(&A, JVST_OP_BAND, oparg_slot(2), oparg_lit(3)),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(2), oparg_lit(3)),
-            newop_br(&A, JVST_OP_CBT, "valid_15"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(2), oparg_lit(3)),
+            newop_br(&A, JVST_VM_BR_EQ, "valid_15"),
 
             oplabel, "invalid_6_17",
             newop_return(&A, 6),
@@ -3754,13 +3754,13 @@ void test_op_dependencies(void)
 
           JVST_OP_PROC, VMLIT(4), VMLIT(0),
           JVST_OP_TOKEN, 0, 0,
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_BEG),
-          JVST_OP_CBT, "true_2",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_BEG),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "true_2",
 
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_END),
-          JVST_OP_CBT, "invalid_1_11",
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_ARRAY_END),
-          JVST_OP_CBT, "invalid_1_11",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_END),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "invalid_1_11",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_ARRAY_END),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "invalid_1_11",
 
           VM_LABEL, "false_15",
           JVST_OP_CONSUME, 0, 0,
@@ -3773,8 +3773,8 @@ void test_op_dependencies(void)
           JVST_OP_MOVE, VMSLOT(0), VMSLOT(3),
           JVST_OP_MOVE, VMSLOT(2), VMSLOT(0),
           JVST_OP_MOVE, VMSLOT(1), VMLIT(1),
-          JVST_OP_IGE, VMSLOT(2), VMSLOT(1),
-          JVST_OP_CBT, "valid_5",
+          JVST_OP_ICMP, VMSLOT(2), VMSLOT(1),
+          JVST_OP_JMP, JVST_VM_BR_GE, "valid_5",
 
           VM_LABEL, "invalid_7_7",
           JVST_OP_RETURN, VMLIT(7), 0,
@@ -3786,24 +3786,24 @@ void test_op_dependencies(void)
           JVST_OP_PROC, VMLIT(1), VMLIT(0),
           VM_LABEL, "loop_2",
           JVST_OP_TOKEN, 0, 0,
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_END),
-          JVST_OP_CBT, "valid_12",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_END),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "valid_12",
 
           VM_LABEL, "false_5",
           JVST_OP_MATCH, VMLIT(0), VMLIT(0),
           JVST_OP_MOVE, VMSLOT(0), VMREG(JVST_VM_M),
-          JVST_OP_IEQ, VMSLOT(0), VMLIT(0),
-          JVST_OP_CBT, "M_7",
+          JVST_OP_ICMP, VMSLOT(0), VMLIT(0),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "M_7",
 
-          JVST_OP_IEQ, VMSLOT(0), VMLIT(1),
-          JVST_OP_CBT, "invalid_8_10",
+          JVST_OP_ICMP, VMSLOT(0), VMLIT(1),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "invalid_8_10",
 
           VM_LABEL, "invalid_9_11",
           JVST_OP_RETURN, VMLIT(9), 0,
 
           VM_LABEL, "M_7",
           JVST_OP_CONSUME, VMLIT(0), VMLIT(0),
-          JVST_OP_BR, "loop_2",
+          JVST_OP_JMP, JVST_VM_BR_ALWAYS, "loop_2",
 
           VM_LABEL, "valid_12",
           JVST_OP_RETURN, VMLIT(0), VMLIT(0),
@@ -3815,43 +3815,43 @@ void test_op_dependencies(void)
           JVST_OP_PROC, VMLIT(3), VMLIT(0),
           VM_LABEL, "loop_2b",
           JVST_OP_TOKEN, 0, 0,
-          JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_END),
-          JVST_OP_CBT, "loop_end_1",
+          JVST_OP_ICMP, VMREG(JVST_VM_TT), VMLIT(SJP_OBJECT_END),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "loop_end_1",
 
           VM_LABEL, "false_5",
           JVST_OP_MATCH, VMLIT(1), VMLIT(0),
           JVST_OP_MOVE, VMSLOT(1), VMREG(JVST_VM_M),
-          JVST_OP_IEQ, VMSLOT(1), VMLIT(0),
-          JVST_OP_CBT, "M_7b",
+          JVST_OP_ICMP, VMSLOT(1), VMLIT(0),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "M_7b",
 
-          JVST_OP_IEQ, VMSLOT(1), VMLIT(1),
-          JVST_OP_CBT, "M_9b",
+          JVST_OP_ICMP, VMSLOT(1), VMLIT(1),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "M_9b",
 
-          JVST_OP_IEQ, VMSLOT(1), VMLIT(2),
-          JVST_OP_CBT, "M_11b",
+          JVST_OP_ICMP, VMSLOT(1), VMLIT(2),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "M_11b",
 
           VM_LABEL, "invalid_9_12",
           JVST_OP_RETURN, VMLIT(9), 0,
 
           VM_LABEL, "M_7b",
           JVST_OP_CONSUME, VMLIT(0), VMLIT(0),
-          JVST_OP_BR, "loop_2b",
+          JVST_OP_JMP, JVST_VM_BR_ALWAYS, "loop_2b",
 
           VM_LABEL, "M_9b",
           JVST_OP_BSET, VMSLOT(0), VMLIT(0),
           JVST_OP_CONSUME, VMLIT(0), VMLIT(0),
-          JVST_OP_BR, "loop_2b",
+          JVST_OP_JMP, JVST_VM_BR_ALWAYS, "loop_2b",
 
           VM_LABEL, "M_11b",
           JVST_OP_BSET, VMSLOT(0), VMLIT(1),
           JVST_OP_CONSUME, VMLIT(0), VMLIT(0),
-          JVST_OP_BR, "loop_2b",
+          JVST_OP_JMP, JVST_VM_BR_ALWAYS, "loop_2b",
 
           VM_LABEL, "loop_end_1",
           JVST_OP_MOVE, VMSLOT(2), VMSLOT(0),
           JVST_OP_BAND, VMSLOT(2), VMLIT(3),
-          JVST_OP_IEQ, VMSLOT(2), VMLIT(3),
-          JVST_OP_CBT, "valid_15",
+          JVST_OP_ICMP, VMSLOT(2), VMLIT(3),
+          JVST_OP_JMP, JVST_VM_BR_EQ, "valid_15",
 
           VM_LABEL, "invalid_6_17",
           JVST_OP_RETURN, VMLIT(6), 0,
@@ -4009,16 +4009,16 @@ void test_op_dependencies(void)
 
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
-            newop_br(&A, JVST_OP_CBT, "true_2"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
+            newop_br(&A, JVST_VM_BR_EQ, "true_2"),
 
             oplabel, "false_8",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_11"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_11"),
 
             oplabel, "false_12",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_11"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_11"),
 
             oplabel, "false_15",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -4031,8 +4031,8 @@ void test_op_dependencies(void)
             newop_load(&A, JVST_OP_MOVE, oparg_slot(0), oparg_slot(3)),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(2), oparg_slot(0)),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(1), oparg_lit(1)),
-            newop_cmp(&A, JVST_OP_IGE, oparg_slot(2), oparg_slot(1)),
-            newop_br(&A, JVST_OP_CBT, "valid_5"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(2), oparg_slot(1)),
+            newop_br(&A, JVST_VM_BR_GE, "valid_5"),
 
             oplabel, "invalid_7_7",
             newop_return(&A, 7),
@@ -4048,25 +4048,25 @@ void test_op_dependencies(void)
 
             oplabel, "loop_2",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "valid_12"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "valid_12"),
 
             oplabel, "false_5",
             newop_match(&A, 0),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(0), oparg_m()),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(0), oparg_lit(0)),
-            newop_br(&A, JVST_OP_CBT, "M_7"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(0), oparg_lit(0)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_7"),
 
             oplabel, "M_next_8",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(0), oparg_lit(1)),
-            newop_br(&A, JVST_OP_CBT, "invalid_8_10"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(0), oparg_lit(1)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_8_10"),
 
             oplabel, "invalid_9_11",
             newop_return(&A, 9),
 
             oplabel, "M_7",
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "loop_2"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_2"),
 
             oplabel, "valid_12",
             newop_return(&A, 0),
@@ -4082,54 +4082,54 @@ void test_op_dependencies(void)
 
             oplabel, "loop_2",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "loop_end_1"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "loop_end_1"),
 
             oplabel, "false_5",
             newop_match(&A, 1),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(1), oparg_m()),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(1), oparg_lit(0)),
-            newop_br(&A, JVST_OP_CBT, "M_7"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(1), oparg_lit(0)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_7"),
 
             oplabel, "M_next_8",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(1), oparg_lit(1)),
-            newop_br(&A, JVST_OP_CBT, "M_9"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(1), oparg_lit(1)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_9"),
 
             oplabel, "M_next_10",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(1), oparg_lit(2)),
-            newop_br(&A, JVST_OP_CBT, "M_11"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(1), oparg_lit(2)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_11"),
 
             oplabel, "M_next_12",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(1), oparg_lit(3)),
-            newop_br(&A, JVST_OP_CBT, "M_13"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(1), oparg_lit(3)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_13"),
 
             oplabel, "invalid_9_14",
             newop_return(&A, 9),
 
             oplabel, "M_7",
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "loop_2"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_2"),
 
             oplabel, "M_9",
             newop_bitop(&A, JVST_OP_BSET, 0, 2),
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "loop_2"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_2"),
 
             oplabel, "M_11",
             newop_bitop(&A, JVST_OP_BSET, 0, 1),
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "loop_2"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_2"),
 
             oplabel, "M_13",
             newop_bitop(&A, JVST_OP_BSET, 0, 0),
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "loop_2"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_2"),
 
             oplabel, "loop_end_1",
             newop_load(&A, JVST_OP_MOVE, oparg_slot(2), oparg_slot(0)),
             newop_instr2(&A, JVST_OP_BAND, oparg_slot(2), oparg_lit(7)),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(2), oparg_lit(7)),
-            newop_br(&A, JVST_OP_CBT, "valid_17"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(2), oparg_lit(7)),
+            newop_br(&A, JVST_VM_BR_EQ, "valid_17"),
 
             oplabel, "invalid_6_19",
             newop_return(&A, 6),
@@ -4400,16 +4400,16 @@ void test_op_dependencies(void)
 
             oplabel, "entry_0",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
-            newop_br(&A, JVST_OP_CBT, "true_2"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_BEG)),
+            newop_br(&A, JVST_VM_BR_EQ, "true_2"),
 
             oplabel, "false_11",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_14"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_14"),
 
             oplabel, "false_15",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
-            newop_br(&A, JVST_OP_CBT, "invalid_1_14"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_ARRAY_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_1_14"),
 
             oplabel, "false_18",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -4421,14 +4421,14 @@ void test_op_dependencies(void)
             newop_instr2(&A, JVST_OP_SPLITV, oparg_lit(0), oparg_slot(0)),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(1), oparg_slot(0)),
             newop_instr2(&A, JVST_OP_BAND, oparg_slot(1), oparg_lit(1)),
-            newop_cmp(&A, JVST_OP_INEQ, oparg_slot(1), oparg_lit(0)),
-            newop_br(&A, JVST_OP_CBT, "and_true_8"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(1), oparg_lit(0)),
+            newop_br(&A, JVST_VM_BR_NE, "and_true_8"),
 
             oplabel, "or_false_9",
             newop_load(&A, JVST_OP_MOVE, oparg_slot(2), oparg_slot(0)),
             newop_instr2(&A, JVST_OP_BAND, oparg_slot(2), oparg_lit(2)),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(2), oparg_lit(2)),
-            newop_br(&A, JVST_OP_CBT, "and_true_8"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(2), oparg_lit(2)),
+            newop_br(&A, JVST_VM_BR_EQ, "and_true_8"),
 
             oplabel, "invalid_7_7",
             newop_return(&A, 7),
@@ -4436,15 +4436,15 @@ void test_op_dependencies(void)
             oplabel, "and_true_8",
             newop_load(&A, JVST_OP_MOVE, oparg_slot(3), oparg_slot(0)),
             newop_instr2(&A, JVST_OP_BAND, oparg_slot(3), oparg_lit(4)),
-            newop_cmp(&A, JVST_OP_INEQ, oparg_slot(3), oparg_lit(0)),
-            newop_br(&A, JVST_OP_CBT, "valid_5"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(3), oparg_lit(0)),
+            newop_br(&A, JVST_VM_BR_NE, "valid_5"),
 
             oplabel, "or_false_10",
             newop_load(&A, JVST_OP_MOVE, oparg_slot(4), oparg_slot(0)),
             newop_instr2(&A, JVST_OP_BAND, oparg_slot(4), oparg_lit(8)),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(4), oparg_lit(8)),
-            newop_br(&A, JVST_OP_CBT, "valid_5"),
-            newop_br(&A, JVST_OP_BR, "invalid_7_7"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(4), oparg_lit(8)),
+            newop_br(&A, JVST_VM_BR_EQ, "valid_5"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "invalid_7_7"),
 
             oplabel, "invalid_1_14",
             newop_return(&A, 1),
@@ -4456,25 +4456,25 @@ void test_op_dependencies(void)
             opslots, 1,
             oplabel, "loop_2",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "valid_12"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "valid_12"),
 
             oplabel, "false_5",
             newop_match(&A, 0),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(0), oparg_m()),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(0), oparg_lit(0)),
-            newop_br(&A, JVST_OP_CBT, "M_7"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(0), oparg_lit(0)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_7"),
 
             oplabel, "M_next_8",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(0), oparg_lit(1)),
-            newop_br(&A, JVST_OP_CBT, "invalid_8_10"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(0), oparg_lit(1)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_8_10"),
 
             oplabel, "invalid_9_11",
             newop_return(&A, 9),
 
             oplabel, "M_7",
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "loop_2"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_2"),
 
             oplabel, "valid_12",
             newop_return(&A, 0),
@@ -4490,54 +4490,54 @@ void test_op_dependencies(void)
 
             oplabel, "loop_2",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "loop_end_1"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "loop_end_1"),
 
             oplabel, "false_5",
             newop_match(&A, 1),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(1), oparg_m()),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(1), oparg_lit(0)),
-            newop_br(&A, JVST_OP_CBT, "M_7"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(1), oparg_lit(0)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_7"),
 
             oplabel, "M_next_8",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(1), oparg_lit(1)),
-            newop_br(&A, JVST_OP_CBT, "M_9"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(1), oparg_lit(1)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_9"),
 
             oplabel, "M_next_10",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(1), oparg_lit(2)),
-            newop_br(&A, JVST_OP_CBT, "M_11"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(1), oparg_lit(2)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_11"),
 
             oplabel, "M_next_12",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(1), oparg_lit(3)),
-            newop_br(&A, JVST_OP_CBT, "M_13"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(1), oparg_lit(3)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_13"),
 
             oplabel, "invalid_9_14",
             newop_return(&A, 9),
 
             oplabel, "M_7",
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "loop_2"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_2"),
 
             oplabel, "M_9",
             newop_bitop(&A, JVST_OP_BSET, 0, 2),
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "loop_2"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_2"),
 
             oplabel, "M_11",
             newop_bitop(&A, JVST_OP_BSET, 0, 1),
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "loop_2"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_2"),
 
             oplabel, "M_13",
             newop_bitop(&A, JVST_OP_BSET, 0, 0),
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "loop_2"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_2"),
 
             oplabel, "loop_end_1",
             newop_load(&A, JVST_OP_MOVE, oparg_slot(2), oparg_slot(0)),
             newop_instr2(&A, JVST_OP_BAND, oparg_slot(2), oparg_lit(7)),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(2), oparg_lit(7)),
-            newop_br(&A, JVST_OP_CBT, "valid_17"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(2), oparg_lit(7)),
+            newop_br(&A, JVST_VM_BR_EQ, "valid_17"),
 
             oplabel, "invalid_6_19",
             newop_return(&A, 6),
@@ -4553,25 +4553,25 @@ void test_op_dependencies(void)
 
             oplabel, "loop_2",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "valid_12"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "valid_12"),
 
             oplabel, "false_5",
             newop_match(&A, 2),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(0), oparg_m()),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(0), oparg_lit(0)),
-            newop_br(&A, JVST_OP_CBT, "M_7"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(0), oparg_lit(0)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_7"),
 
             oplabel, "M_next_8",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(0), oparg_lit(1)),
-            newop_br(&A, JVST_OP_CBT, "invalid_8_10"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(0), oparg_lit(1)),
+            newop_br(&A, JVST_VM_BR_EQ, "invalid_8_10"),
 
             oplabel, "invalid_9_11",
             newop_return(&A, 9),
 
             oplabel, "M_7",
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "loop_2"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_2"),
 
             oplabel, "valid_12",
             newop_return(&A, 0),
@@ -4587,45 +4587,45 @@ void test_op_dependencies(void)
 
             oplabel, "loop_2",
             newop_instr(&A, JVST_OP_TOKEN),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
-            newop_br(&A, JVST_OP_CBT, "loop_end_1"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_tt(), oparg_tok(SJP_OBJECT_END)),
+            newop_br(&A, JVST_VM_BR_EQ, "loop_end_1"),
 
             oplabel, "false_5",
             newop_match(&A, 3),
             newop_load(&A, JVST_OP_MOVE, oparg_slot(1), oparg_m()),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(1), oparg_lit(0)),
-            newop_br(&A, JVST_OP_CBT, "M_7"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(1), oparg_lit(0)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_7"),
 
             oplabel, "M_next_8",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(1), oparg_lit(1)),
-            newop_br(&A, JVST_OP_CBT, "M_9"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(1), oparg_lit(1)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_9"),
 
             oplabel, "M_next_10",
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(1), oparg_lit(2)),
-            newop_br(&A, JVST_OP_CBT, "M_11"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(1), oparg_lit(2)),
+            newop_br(&A, JVST_VM_BR_EQ, "M_11"),
 
             oplabel, "invalid_9_12",
             newop_return(&A, 9),
 
             oplabel, "M_7",
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "loop_2"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_2"),
 
             oplabel, "M_9",
             newop_bitop(&A, JVST_OP_BSET, 0, 1),
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "loop_2"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_2"),
 
             oplabel, "M_11",
             newop_bitop(&A, JVST_OP_BSET, 0, 0),
             newop_instr(&A, JVST_OP_CONSUME),
-            newop_br(&A, JVST_OP_BR, "loop_2"),
+            newop_br(&A, JVST_VM_BR_ALWAYS, "loop_2"),
 
             oplabel, "loop_end_1",
             newop_load(&A, JVST_OP_MOVE, oparg_slot(2), oparg_slot(0)),
             newop_instr2(&A, JVST_OP_BAND, oparg_slot(2), oparg_lit(3)),
-            newop_cmp(&A, JVST_OP_IEQ, oparg_slot(2), oparg_lit(3)),
-            newop_br(&A, JVST_OP_CBT, "valid_15"),
+            newop_cmp(&A, JVST_OP_ICMP, oparg_slot(2), oparg_lit(3)),
+            newop_br(&A, JVST_VM_BR_EQ, "valid_15"),
 
             oplabel, "invalid_6_17",
             newop_return(&A, 6),

--- a/tests/unit/test_op.c
+++ b/tests/unit/test_op.c
@@ -277,10 +277,10 @@ test_op_empty_schema(void)
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_8",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             oplabel, "invalid_1_3",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             NULL
           ),
@@ -324,10 +324,10 @@ test_op_empty_schema(void)
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_8",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             oplabel, "invalid_1_3",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             NULL
           ),
@@ -343,9 +343,9 @@ test_op_empty_schema(void)
           JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_ARRAY_END),
           JVST_OP_CBT, "invalid_1_3",
           JVST_OP_CONSUME, 0, 0,
-          JVST_OP_VALID, 0, 0,
+          JVST_OP_RETURN, 0, 0,
           VM_LABEL, "invalid_1_3",
-          JVST_OP_INVALID, VMLIT(1), 0,
+          JVST_OP_RETURN, VMLIT(1), 0,
           VM_END)
     },
 
@@ -385,13 +385,13 @@ static void test_op_type_constraints(void)
             newop_br(&A, JVST_OP_CBT, "true_2"),
 
             oplabel, "invalid_1_5",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             oplabel, "true_2",
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_3",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             NULL
           ),
@@ -426,13 +426,13 @@ static void test_op_type_constraints(void)
             newop_br(&A, JVST_OP_CBT, "true_2"),
 
             oplabel, "invalid_1_5",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             oplabel, "true_2",
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_3",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             NULL
           ),
@@ -481,13 +481,13 @@ static void test_op_type_constraints(void)
             newop_br(&A, JVST_OP_CBT, "true_6"),
 
             oplabel, "invalid_1_8",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             oplabel, "true_2",
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_3",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             oplabel, "true_6",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -545,20 +545,20 @@ static void test_op_type_integer(void)
             newop_br(&A, JVST_OP_CBT, "true_2"),
 
             oplabel, "invalid_1_9",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             oplabel, "true_2",
             newop_cmp(&A, JVST_OP_FINT, oparg_tnum(), oparg_none()),
             newop_br(&A, JVST_OP_CBT, "true_4"),
 
             oplabel, "invalid_2_7",
-            newop_invalid(&A, 2),
+            newop_return(&A, 2),
 
             oplabel, "true_4",
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_5",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             NULL
           ),
@@ -594,20 +594,20 @@ static void test_op_type_integer(void)
             newop_br(&A, JVST_OP_CBT, "true_2"),
 
             oplabel, "invalid_1_9",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             oplabel, "true_2",
             newop_cmp(&A, JVST_OP_FINT, oparg_tnum(), oparg_none()),
             newop_br(&A, JVST_OP_CBT, "valid_5"),
 
             oplabel, "invalid_2_7",
-            newop_invalid(&A, 2),
+            newop_return(&A, 2),
 
             oplabel, "true_4",
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_5",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             NULL
           ),
@@ -620,19 +620,19 @@ static void test_op_type_integer(void)
           JVST_OP_TOKEN, 0, 0,
           JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_NUMBER),
           JVST_OP_CBT, "true_2",
-          JVST_OP_INVALID, VMLIT(1), 0,
+          JVST_OP_RETURN, VMLIT(1), 0,
 
           VM_LABEL, "true_2",
           JVST_OP_FINT, VMREG(JVST_VM_TNUM), VMLIT(0),
           JVST_OP_CBT, "true_4",
 
-          JVST_OP_INVALID, VMLIT(2), 0,
+          JVST_OP_RETURN, VMLIT(2), 0,
 
           VM_LABEL, "true_4",
           JVST_OP_CONSUME, 0, 0,
 
           VM_LABEL, "valid_5",
-          JVST_OP_VALID, 0, 0,
+          JVST_OP_RETURN, 0, 0,
           VM_END)
     },
 
@@ -686,7 +686,7 @@ static void test_op_minimum(void)
             newop_br(&A, JVST_OP_CBT, "true_2"),
 
             oplabel, "invalid_1_9",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             oplabel, "true_2",
             newop_load(&A, JVST_OP_MOVE, oparg_slot(1), oparg_tnum()),
@@ -695,13 +695,13 @@ static void test_op_minimum(void)
             newop_br(&A, JVST_OP_CBT, "true_4"),
 
             oplabel, "invalid_3_7",
-            newop_invalid(&A, 3),
+            newop_return(&A, 3),
 
             oplabel, "true_4",
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_5",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             NULL
           ),
@@ -781,7 +781,7 @@ static void test_op_minimum(void)
             newop_br(&A, JVST_OP_CBT, "true_2"),
 
             oplabel, "invalid_1_9",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             oplabel, "true_2",
             newop_load(&A, JVST_OP_MOVE, oparg_slot(1), oparg_tnum()),
@@ -790,13 +790,13 @@ static void test_op_minimum(void)
             newop_br(&A, JVST_OP_CBT, "true_4"),
 
             oplabel, "invalid_3_7",
-            newop_invalid(&A, 3),
+            newop_return(&A, 3),
 
             oplabel, "true_4",
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_5",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             NULL
           ),
@@ -811,7 +811,7 @@ static void test_op_minimum(void)
           JVST_OP_TOKEN, 0, 0,
           JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_NUMBER),
           JVST_OP_CBT, "true_2",
-          JVST_OP_INVALID, VMLIT(1), 0,
+          JVST_OP_RETURN, VMLIT(1), 0,
 
           VM_LABEL, "true_2",
           JVST_OP_MOVE, VMSLOT(1), VMREG(JVST_VM_TNUM),
@@ -819,13 +819,13 @@ static void test_op_minimum(void)
           JVST_OP_FGE, VMSLOT(1), VMSLOT(0),
           JVST_OP_CBT, "true_4",
 
-          JVST_OP_INVALID, VMLIT(3), 0,
+          JVST_OP_RETURN, VMLIT(3), 0,
 
           VM_LABEL, "true_4",
           JVST_OP_CONSUME, 0, 0,
 
           VM_LABEL, "valid_5",
-          JVST_OP_VALID, 0, 0,
+          JVST_OP_RETURN, 0, 0,
           VM_END)
     },
 
@@ -895,7 +895,7 @@ static void test_op_multiple_of(void)
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_5",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             oplabel, "true_2",
             newop_load(&A, JVST_OP_FLOAD, oparg_slot(0), oparg_lit(0)),
@@ -903,14 +903,14 @@ static void test_op_multiple_of(void)
             newop_br(&A, JVST_OP_CBT, "true_4"),
 
             oplabel, "invalid_17_7",
-            newop_invalid(&A, 17),
+            newop_return(&A, 17),
 
             oplabel, "true_4",
             newop_instr(&A, JVST_OP_CONSUME),
             newop_br(&A, JVST_OP_BR, "valid_5"),
 
             oplabel, "invalid_1_11",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             NULL
           ),
@@ -975,7 +975,7 @@ static void test_op_multiple_of(void)
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_5",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             oplabel, "true_2",
             newop_load(&A, JVST_OP_FLOAD, oparg_slot(0), oparg_lit(0)),
@@ -983,14 +983,14 @@ static void test_op_multiple_of(void)
             newop_br(&A, JVST_OP_CBT, "true_4"),
 
             oplabel, "invalid_17_7",
-            newop_invalid(&A, 17),
+            newop_return(&A, 17),
 
             oplabel, "true_4",
             newop_instr(&A, JVST_OP_CONSUME),
             newop_br(&A, JVST_OP_BR, "valid_5"),
 
             oplabel, "invalid_1_11",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             NULL
           ),
@@ -1018,21 +1018,21 @@ static void test_op_multiple_of(void)
           JVST_OP_CONSUME, 0, 0,
 
           VM_LABEL, "valid_5",
-          JVST_OP_VALID, 0, 0,
+          JVST_OP_RETURN, 0, 0,
 
           VM_LABEL, "true_2",
           JVST_OP_FLOAD, VMSLOT(0), VMLIT(0),
           JVST_OP_FINT, VMREG(JVST_VM_TNUM), VMSLOT(0),
           JVST_OP_CBT, "true_4",
 
-          JVST_OP_INVALID, VMLIT(17), 0,
+          JVST_OP_RETURN, VMLIT(17), 0,
 
           VM_LABEL, "true_4",
           JVST_OP_CONSUME, 0, 0,
           JVST_OP_BR, "valid_5",
 
           VM_LABEL, "invalid_1_11",
-          JVST_OP_INVALID, VMLIT(1), 0,
+          JVST_OP_RETURN, VMLIT(1), 0,
 
           VM_END)
     },
@@ -1088,21 +1088,21 @@ static void test_op_multiple_of(void)
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_5",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             oplabel, "true_2",
             newop_cmp(&A, JVST_OP_FINT, oparg_tnum(), oparg_lit(3)),
             newop_br(&A, JVST_OP_CBT, "true_4"),
 
             oplabel, "invalid_17_7",
-            newop_invalid(&A, 17),
+            newop_return(&A, 17),
 
             oplabel, "true_4",
             newop_instr(&A, JVST_OP_CONSUME),
             newop_br(&A, JVST_OP_BR, "valid_5"),
 
             oplabel, "invalid_1_11",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             NULL
           ),
@@ -1163,7 +1163,7 @@ static void test_op_multiple_of(void)
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_5",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             oplabel, "true_2",
             newop_load(&A, JVST_OP_FLOAD, oparg_slot(0), oparg_lit(0)),
@@ -1171,14 +1171,14 @@ static void test_op_multiple_of(void)
             newop_br(&A, JVST_OP_CBT, "true_4"),
 
             oplabel, "invalid_17_7",
-            newop_invalid(&A, 17),
+            newop_return(&A, 17),
 
             oplabel, "true_4",
             newop_instr(&A, JVST_OP_CONSUME),
             newop_br(&A, JVST_OP_BR, "valid_5"),
 
             oplabel, "invalid_1_11",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             NULL
           ),
@@ -1204,20 +1204,20 @@ static void test_op_multiple_of(void)
           JVST_OP_CONSUME, 0, 0,
 
           VM_LABEL, "valid_5",
-          JVST_OP_VALID, 0, 0,
+          JVST_OP_RETURN, 0, 0,
 
           VM_LABEL, "true_2",
           JVST_OP_FINT, VMREG(JVST_VM_TNUM), VMLIT(3),
           JVST_OP_CBT, "true_4",
 
-          JVST_OP_INVALID, VMLIT(17), 0,
+          JVST_OP_RETURN, VMLIT(17), 0,
 
           VM_LABEL, "true_4",
           JVST_OP_CONSUME, 0, 0,
           JVST_OP_BR, "valid_5",
 
           VM_LABEL, "invalid_1_11",
-          JVST_OP_INVALID, VMLIT(1), 0,
+          JVST_OP_RETURN, VMLIT(1), 0,
 
           VM_END)
     },
@@ -1345,7 +1345,7 @@ static void test_op_properties(void)
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_15",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             oplabel, "loop_4",
             newop_instr(&A, JVST_OP_TOKEN),
@@ -1367,7 +1367,7 @@ static void test_op_properties(void)
             newop_br(&A, JVST_OP_CBT, "M_13"),
 
             oplabel, "invalid_9_14",
-            newop_invalid(&A, 9),
+            newop_return(&A, 9),
 
             oplabel, "M_9",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -1382,7 +1382,7 @@ static void test_op_properties(void)
             newop_br(&A, JVST_OP_BR, "loop_4"),
 
             oplabel, "invalid_1_19",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             NULL
           ),
@@ -1394,13 +1394,13 @@ static void test_op_properties(void)
             newop_br(&A, JVST_OP_CBT, "true_2"),
 
             oplabel, "invalid_1_5",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             oplabel, "true_2",
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_3",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             NULL
           ),
@@ -1412,13 +1412,13 @@ static void test_op_properties(void)
             newop_br(&A, JVST_OP_CBT, "true_2"),
 
             oplabel, "invalid_1_5",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             oplabel, "true_2",
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_3",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             NULL
           ),
@@ -1539,7 +1539,7 @@ static void test_op_properties(void)
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_15",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             oplabel, "loop_4",
             newop_instr(&A, JVST_OP_TOKEN),
@@ -1561,7 +1561,7 @@ static void test_op_properties(void)
             newop_br(&A, JVST_OP_CBT, "M_13"),
 
             oplabel, "invalid_9_14",
-            newop_invalid(&A, 9),
+            newop_return(&A, 9),
 
             oplabel, "M_9",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -1576,7 +1576,7 @@ static void test_op_properties(void)
             newop_br(&A, JVST_OP_BR, "loop_4"),
 
             oplabel, "invalid_1_19",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             NULL
           ),
@@ -1588,13 +1588,13 @@ static void test_op_properties(void)
             newop_br(&A, JVST_OP_CBT, "true_2"),
 
             oplabel, "invalid_1_5",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             oplabel, "true_2",
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_3",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             NULL
           ),
@@ -1606,13 +1606,13 @@ static void test_op_properties(void)
             newop_br(&A, JVST_OP_CBT, "true_2"),
 
             oplabel, "invalid_1_5",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             oplabel, "true_2",
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_3",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             NULL
           ),
@@ -1638,7 +1638,7 @@ static void test_op_properties(void)
           JVST_OP_CONSUME, 0, 0,
 
           VM_LABEL, "valid_15",
-          JVST_OP_VALID, 0, 0,
+          JVST_OP_RETURN, 0, 0,
 
           VM_LABEL, "loop_4",
           JVST_OP_TOKEN, 0, 0,
@@ -1656,7 +1656,7 @@ static void test_op_properties(void)
           JVST_OP_IEQ, VMSLOT(0), VMLIT(2),
           JVST_OP_CBT, "M_13",
 
-          JVST_OP_INVALID, VMLIT(9), 0,
+          JVST_OP_RETURN, VMLIT(9), 0,
 
           VM_LABEL, "M_9",
           JVST_OP_CONSUME, 0, 0,
@@ -1671,7 +1671,7 @@ static void test_op_properties(void)
           JVST_OP_BR, "loop_4",
 
           VM_LABEL, "invalid_1_19",
-          JVST_OP_INVALID, VMLIT(1), 0,
+          JVST_OP_RETURN, VMLIT(1), 0,
 
           JVST_OP_PROC, VMLIT(0), VMLIT(0),
 
@@ -1679,13 +1679,13 @@ static void test_op_properties(void)
           JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_STRING),
           JVST_OP_CBT, "true_2a",
 
-          JVST_OP_INVALID, VMLIT(1), 0,
+          JVST_OP_RETURN, VMLIT(1), 0,
 
           VM_LABEL, "true_2a",
           JVST_OP_CONSUME, 0, 0,
 
           VM_LABEL, "valid_3a",
-          JVST_OP_VALID, 0, 0,
+          JVST_OP_RETURN, 0, 0,
 
           JVST_OP_PROC, VMLIT(0), VMLIT(0),
 
@@ -1693,13 +1693,13 @@ static void test_op_properties(void)
           JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_NUMBER),
           JVST_OP_CBT, "true_2b",
 
-          JVST_OP_INVALID, VMLIT(1), 0,
+          JVST_OP_RETURN, VMLIT(1), 0,
 
           VM_LABEL, "true_2b",
           JVST_OP_CONSUME, 0, 0,
 
           VM_LABEL, "valid_3b",
-          JVST_OP_VALID, 0, 0,
+          JVST_OP_RETURN, 0, 0,
 
           VM_END)
     },
@@ -1799,7 +1799,7 @@ static void test_op_properties(void)
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_15",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             oplabel, "loop_4",
             newop_instr(&A, JVST_OP_TOKEN),
@@ -1821,7 +1821,7 @@ static void test_op_properties(void)
             newop_br(&A, JVST_OP_CBT, "M_13"),
 
             oplabel, "invalid_9_14",
-            newop_invalid(&A, 9),
+            newop_return(&A, 9),
 
             oplabel, "M_9",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -1836,7 +1836,7 @@ static void test_op_properties(void)
             newop_br(&A, JVST_OP_BR, "loop_4"),
 
             oplabel, "invalid_1_19",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             NULL
           ),
@@ -1846,7 +1846,7 @@ static void test_op_properties(void)
             newop_instr(&A, JVST_OP_TOKEN),
 
             oplabel, "invalid_1_1",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             NULL
           ),
@@ -1858,13 +1858,13 @@ static void test_op_properties(void)
             newop_br(&A, JVST_OP_CBT, "true_2"),
 
             oplabel, "invalid_1_5",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             oplabel, "true_2",
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_3",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             NULL
           ),
@@ -1983,7 +1983,7 @@ void test_op_minmax_properties_1(void)
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_10",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             oplabel, "loop_4",
             newop_instr(&A, JVST_OP_TOKEN),
@@ -2004,10 +2004,10 @@ void test_op_minmax_properties_1(void)
             newop_br(&A, JVST_OP_CBT, "valid_10"),
 
             oplabel, "invalid_4_12",
-            newop_invalid(&A, 4),
+            newop_return(&A, 4),
 
             oplabel, "invalid_1_16",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             NULL
           ),
@@ -2098,7 +2098,7 @@ void test_op_minmax_properties_1(void)
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_10",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             oplabel, "loop_4",
             newop_instr(&A, JVST_OP_TOKEN),
@@ -2119,10 +2119,10 @@ void test_op_minmax_properties_1(void)
             newop_br(&A, JVST_OP_CBT, "valid_10"),
 
             oplabel, "invalid_5_12",
-            newop_invalid(&A, 5),
+            newop_return(&A, 5),
 
             oplabel, "invalid_1_16",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             NULL
           ),
@@ -2213,7 +2213,7 @@ void test_op_minmax_properties_1(void)
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_12",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             oplabel, "loop_4",
             newop_instr(&A, JVST_OP_TOKEN),
@@ -2234,7 +2234,7 @@ void test_op_minmax_properties_1(void)
             newop_br(&A, JVST_OP_CBT, "true_9"),
 
             oplabel, "invalid_4_16",
-            newop_invalid(&A, 4),
+            newop_return(&A, 4),
 
             oplabel, "true_9",
             newop_load(&A, JVST_OP_MOVE, oparg_slot(1), oparg_slot(0)),
@@ -2244,10 +2244,10 @@ void test_op_minmax_properties_1(void)
             newop_br(&A, JVST_OP_CBT, "valid_12"),
 
             oplabel, "invalid_5_14",
-            newop_invalid(&A, 5),
+            newop_return(&A, 5),
 
             oplabel, "invalid_1_20",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             NULL
           ),
@@ -2338,7 +2338,7 @@ void test_op_minmax_properties_1(void)
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_12",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             oplabel, "loop_4",
             newop_instr(&A, JVST_OP_TOKEN),
@@ -2359,7 +2359,7 @@ void test_op_minmax_properties_1(void)
             newop_br(&A, JVST_OP_CBT, "true_9"),
 
             oplabel, "invalid_4_16",
-            newop_invalid(&A, 4),
+            newop_return(&A, 4),
 
             oplabel, "true_9",
             newop_load(&A, JVST_OP_MOVE, oparg_slot(1), oparg_slot(0)),
@@ -2369,10 +2369,10 @@ void test_op_minmax_properties_1(void)
             newop_br(&A, JVST_OP_CBT, "valid_12"),
 
             oplabel, "invalid_5_14",
-            newop_invalid(&A, 5),
+            newop_return(&A, 5),
 
             oplabel, "invalid_1_20",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             NULL
           ),
@@ -2396,7 +2396,7 @@ void test_op_minmax_properties_1(void)
           JVST_OP_CONSUME, 0, 0,
 
           VM_LABEL, "valid_12",
-          JVST_OP_VALID, 0, 0,
+          JVST_OP_RETURN, 0, 0,
 
           VM_LABEL, "loop_4",
           JVST_OP_TOKEN, 0, 0,
@@ -2415,7 +2415,7 @@ void test_op_minmax_properties_1(void)
           JVST_OP_IGE, VMSLOT(6), VMSLOT(5),
           JVST_OP_CBT, "true_9",
 
-          JVST_OP_INVALID, VMLIT(4), 0,
+          JVST_OP_RETURN, VMLIT(4), 0,
 
           VM_LABEL, "true_9",
           JVST_OP_MOVE, VMSLOT(1), VMSLOT(0),
@@ -2424,10 +2424,10 @@ void test_op_minmax_properties_1(void)
           JVST_OP_ILE, VMSLOT(3), VMSLOT(2),
           JVST_OP_CBT, "valid_12",
 
-          JVST_OP_INVALID, VMLIT(5), 0,
+          JVST_OP_RETURN, VMLIT(5), 0,
 
           VM_LABEL, "invalid_1_20",
-          JVST_OP_INVALID, VMLIT(1), 0,
+          JVST_OP_RETURN, VMLIT(1), 0,
 
           VM_END)
     },
@@ -2570,7 +2570,7 @@ void test_op_minproperties_2(void)
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_17",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             oplabel, "loop_4",
             newop_instr(&A, JVST_OP_TOKEN),
@@ -2592,7 +2592,7 @@ void test_op_minproperties_2(void)
             newop_br(&A, JVST_OP_CBT, "M_13"),
 
             oplabel, "invalid_9_14",
-            newop_invalid(&A, 9),
+            newop_return(&A, 9),
 
             oplabel, "M_9",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -2617,10 +2617,10 @@ void test_op_minproperties_2(void)
             newop_br(&A, JVST_OP_CBT, "valid_17"),
 
             oplabel, "invalid_4_19",
-            newop_invalid(&A, 4),
+            newop_return(&A, 4),
 
             oplabel, "invalid_1_23",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             NULL
           ),
@@ -2632,13 +2632,13 @@ void test_op_minproperties_2(void)
             newop_br(&A, JVST_OP_CBT, "true_2"),
 
             oplabel, "invalid_1_5",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             oplabel, "true_2",
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_3",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             NULL
           ),
@@ -2650,13 +2650,13 @@ void test_op_minproperties_2(void)
             newop_br(&A, JVST_OP_CBT, "true_2"),
 
             oplabel, "invalid_1_5",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             oplabel, "true_2",
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_3",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             NULL
           ),
@@ -2815,7 +2815,7 @@ void test_op_required(void)
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_17",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             oplabel, "loop_4",
             newop_instr(&A, JVST_OP_TOKEN),
@@ -2837,7 +2837,7 @@ void test_op_required(void)
             newop_br(&A, JVST_OP_CBT, "M_13"),
 
             oplabel, "invalid_9_14",
-            newop_invalid(&A, 9),
+            newop_return(&A, 9),
 
             oplabel, "M_9",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -2859,10 +2859,10 @@ void test_op_required(void)
             newop_br(&A, JVST_OP_CBT, "valid_17"),
 
             oplabel, "invalid_6_19",
-            newop_invalid(&A, 6),
+            newop_return(&A, 6),
 
             oplabel, "invalid_1_23",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             NULL
           ),
@@ -2874,13 +2874,13 @@ void test_op_required(void)
             newop_br(&A, JVST_OP_CBT, "true_2"),
 
             oplabel, "invalid_1_5",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             oplabel, "true_2",
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_3",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             NULL
           ),
@@ -2892,13 +2892,13 @@ void test_op_required(void)
             newop_br(&A, JVST_OP_CBT, "true_2"),
 
             oplabel, "invalid_1_5",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             oplabel, "true_2",
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_3",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             NULL
           ),
@@ -3032,7 +3032,7 @@ void test_op_required(void)
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_17",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             oplabel, "loop_4",
             newop_instr(&A, JVST_OP_TOKEN),
@@ -3054,7 +3054,7 @@ void test_op_required(void)
             newop_br(&A, JVST_OP_CBT, "M_13"),
 
             oplabel, "invalid_9_14",
-            newop_invalid(&A, 9),
+            newop_return(&A, 9),
 
             oplabel, "M_9",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -3076,10 +3076,10 @@ void test_op_required(void)
             newop_br(&A, JVST_OP_CBT, "valid_17"),
 
             oplabel, "invalid_6_19",
-            newop_invalid(&A, 6),
+            newop_return(&A, 6),
 
             oplabel, "invalid_1_23",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             NULL
           ),
@@ -3091,13 +3091,13 @@ void test_op_required(void)
             newop_br(&A, JVST_OP_CBT, "true_2"),
 
             oplabel, "invalid_1_5",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             oplabel, "true_2",
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_3",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             NULL
           ),
@@ -3109,13 +3109,13 @@ void test_op_required(void)
             newop_br(&A, JVST_OP_CBT, "true_2"),
 
             oplabel, "invalid_1_5",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             oplabel, "true_2",
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_3",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             NULL
           ),
@@ -3141,7 +3141,7 @@ void test_op_required(void)
           JVST_OP_CONSUME, 0, 0,
 
           VM_LABEL, "valid_17",
-          JVST_OP_VALID, 0, 0,
+          JVST_OP_RETURN, 0, 0,
 
           VM_LABEL, "loop_4",
           JVST_OP_TOKEN, 0, 0,
@@ -3159,7 +3159,7 @@ void test_op_required(void)
           JVST_OP_IEQ, VMSLOT(1), VMLIT(2),
           JVST_OP_CBT, "M_13",
 
-          JVST_OP_INVALID, VMLIT(9), 0,
+          JVST_OP_RETURN, VMLIT(9), 0,
 
           VM_LABEL, "M_9",
           JVST_OP_CONSUME, VMLIT(0), VMLIT(0),
@@ -3180,10 +3180,10 @@ void test_op_required(void)
           JVST_OP_IEQ, VMSLOT(2), VMLIT(1),
           JVST_OP_CBT, "valid_17",
 
-          JVST_OP_INVALID, VMLIT(6), 0,
+          JVST_OP_RETURN, VMLIT(6), 0,
 
           VM_LABEL, "invalid_1_23",
-          JVST_OP_INVALID, VMLIT(1), 0,
+          JVST_OP_RETURN, VMLIT(1), 0,
 
           JVST_OP_PROC, VMLIT(0), VMLIT(0),
 
@@ -3191,13 +3191,13 @@ void test_op_required(void)
           JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_STRING),
           JVST_OP_CBT, "true_2a",
 
-          JVST_OP_INVALID, VMLIT(1), 0,
+          JVST_OP_RETURN, VMLIT(1), 0,
 
           VM_LABEL, "true_2a",
           JVST_OP_CONSUME, 0, 0,
 
           VM_LABEL, "valid_3a",
-          JVST_OP_VALID, 0, 0,
+          JVST_OP_RETURN, 0, 0,
 
           JVST_OP_PROC, VMLIT(0), VMLIT(0),
 
@@ -3205,13 +3205,13 @@ void test_op_required(void)
           JVST_OP_IEQ, VMREG(JVST_VM_TT), VMLIT(SJP_NUMBER),
           JVST_OP_CBT, "true_2b",
 
-          JVST_OP_INVALID, VMLIT(1), 0,
+          JVST_OP_RETURN, VMLIT(1), 0,
 
           VM_LABEL, "true_2b",
           JVST_OP_CONSUME, 0, 0,
 
           VM_LABEL, "valid_3b",
-          JVST_OP_VALID, 0, 0,
+          JVST_OP_RETURN, 0, 0,
 
           VM_END)
     },
@@ -3381,7 +3381,7 @@ void test_op_dependencies(void)
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_5",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             oplabel, "true_2",
             newop_instr2(&A, JVST_OP_SPLIT, oparg_lit(0), oparg_slot(3)),
@@ -3392,10 +3392,10 @@ void test_op_dependencies(void)
             newop_br(&A, JVST_OP_CBT, "valid_5"),
 
             oplabel, "invalid_7_7",
-            newop_invalid(&A, 7),
+            newop_return(&A, 7),
 
             oplabel, "invalid_1_11",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             NULL
           ),
@@ -3419,17 +3419,17 @@ void test_op_dependencies(void)
             newop_br(&A, JVST_OP_CBT, "invalid_8_10"),
 
             oplabel, "invalid_9_11",
-            newop_invalid(&A, 9),
+            newop_return(&A, 9),
 
             oplabel, "M_7",
             newop_instr(&A, JVST_OP_CONSUME),
             newop_br(&A, JVST_OP_BR, "loop_2"),
 
             oplabel, "valid_12",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             oplabel, "invalid_8_10",
-            newop_invalid(&A, 8),
+            newop_return(&A, 8),
 
             NULL
           ),
@@ -3457,7 +3457,7 @@ void test_op_dependencies(void)
             newop_br(&A, JVST_OP_CBT, "M_11"),
 
             oplabel, "invalid_9_12",
-            newop_invalid(&A, 9),
+            newop_return(&A, 9),
 
             oplabel, "M_7",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -3480,10 +3480,10 @@ void test_op_dependencies(void)
             newop_br(&A, JVST_OP_CBT, "valid_15"),
 
             oplabel, "invalid_6_17",
-            newop_invalid(&A, 6),
+            newop_return(&A, 6),
 
             oplabel, "valid_15",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             NULL
           ),
@@ -3638,7 +3638,7 @@ void test_op_dependencies(void)
             newop_br(&A, JVST_OP_CBT, "invalid_1_11"),
 
             oplabel, "valid_5",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             oplabel, "true_2",
             newop_instr2(&A, JVST_OP_SPLIT, oparg_lit(0), oparg_slot(3)),
@@ -3649,10 +3649,10 @@ void test_op_dependencies(void)
             newop_br(&A, JVST_OP_CBT, "valid_5"),
 
             oplabel, "invalid_7_7",
-            newop_invalid(&A, 7),
+            newop_return(&A, 7),
 
             oplabel, "invalid_1_11",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             NULL
           ),
@@ -3676,17 +3676,17 @@ void test_op_dependencies(void)
             newop_br(&A, JVST_OP_CBT, "invalid_8_10"),
 
             oplabel, "invalid_9_11",
-            newop_invalid(&A, 9),
+            newop_return(&A, 9),
 
             oplabel, "M_7",
             newop_instr(&A, JVST_OP_CONSUME),
             newop_br(&A, JVST_OP_BR, "loop_2"),
 
             oplabel, "valid_12",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             oplabel, "invalid_8_10",
-            newop_invalid(&A, 8),
+            newop_return(&A, 8),
 
             NULL
           ),
@@ -3714,7 +3714,7 @@ void test_op_dependencies(void)
             newop_br(&A, JVST_OP_CBT, "M_11"),
 
             oplabel, "invalid_9_12",
-            newop_invalid(&A, 9),
+            newop_return(&A, 9),
 
             oplabel, "M_7",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -3737,10 +3737,10 @@ void test_op_dependencies(void)
             newop_br(&A, JVST_OP_CBT, "valid_15"),
 
             oplabel, "invalid_6_17",
-            newop_invalid(&A, 6),
+            newop_return(&A, 6),
 
             oplabel, "valid_15",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             NULL
           ),
@@ -3766,7 +3766,7 @@ void test_op_dependencies(void)
           JVST_OP_CONSUME, 0, 0,
 
           VM_LABEL, "valid_5",
-          JVST_OP_VALID, 0, 0,
+          JVST_OP_RETURN, 0, 0,
 
           VM_LABEL, "true_2",
           JVST_OP_SPLIT, VMLIT(0), VMSLOT(3),
@@ -3777,10 +3777,10 @@ void test_op_dependencies(void)
           JVST_OP_CBT, "valid_5",
 
           VM_LABEL, "invalid_7_7",
-          JVST_OP_INVALID, VMLIT(7), 0,
+          JVST_OP_RETURN, VMLIT(7), 0,
 
           VM_LABEL, "invalid_1_11",
-          JVST_OP_INVALID, VMLIT(1), 0,
+          JVST_OP_RETURN, VMLIT(1), 0,
 
 
           JVST_OP_PROC, VMLIT(1), VMLIT(0),
@@ -3799,17 +3799,17 @@ void test_op_dependencies(void)
           JVST_OP_CBT, "invalid_8_10",
 
           VM_LABEL, "invalid_9_11",
-          JVST_OP_INVALID, VMLIT(9), 0,
+          JVST_OP_RETURN, VMLIT(9), 0,
 
           VM_LABEL, "M_7",
           JVST_OP_CONSUME, VMLIT(0), VMLIT(0),
           JVST_OP_BR, "loop_2",
 
           VM_LABEL, "valid_12",
-          JVST_OP_VALID, VMLIT(0), VMLIT(0),
+          JVST_OP_RETURN, VMLIT(0), VMLIT(0),
 
           VM_LABEL, "invalid_8_10",
-          JVST_OP_INVALID, VMLIT(8), 0,
+          JVST_OP_RETURN, VMLIT(8), 0,
 
 
           JVST_OP_PROC, VMLIT(3), VMLIT(0),
@@ -3831,7 +3831,7 @@ void test_op_dependencies(void)
           JVST_OP_CBT, "M_11b",
 
           VM_LABEL, "invalid_9_12",
-          JVST_OP_INVALID, VMLIT(9), 0,
+          JVST_OP_RETURN, VMLIT(9), 0,
 
           VM_LABEL, "M_7b",
           JVST_OP_CONSUME, VMLIT(0), VMLIT(0),
@@ -3854,10 +3854,10 @@ void test_op_dependencies(void)
           JVST_OP_CBT, "valid_15",
 
           VM_LABEL, "invalid_6_17",
-          JVST_OP_INVALID, VMLIT(6), 0,
+          JVST_OP_RETURN, VMLIT(6), 0,
 
           VM_LABEL, "valid_15",
-          JVST_OP_VALID, VMLIT(0), VMLIT(0),
+          JVST_OP_RETURN, VMLIT(0), VMLIT(0),
 
           VM_END)
     },
@@ -4024,7 +4024,7 @@ void test_op_dependencies(void)
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_5",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             oplabel, "true_2",
             newop_instr2(&A, JVST_OP_SPLIT, oparg_lit(0), oparg_slot(3)),
@@ -4035,10 +4035,10 @@ void test_op_dependencies(void)
             newop_br(&A, JVST_OP_CBT, "valid_5"),
 
             oplabel, "invalid_7_7",
-            newop_invalid(&A, 7),
+            newop_return(&A, 7),
 
             oplabel, "invalid_1_11",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             NULL
           ),
@@ -4062,17 +4062,17 @@ void test_op_dependencies(void)
             newop_br(&A, JVST_OP_CBT, "invalid_8_10"),
 
             oplabel, "invalid_9_11",
-            newop_invalid(&A, 9),
+            newop_return(&A, 9),
 
             oplabel, "M_7",
             newop_instr(&A, JVST_OP_CONSUME),
             newop_br(&A, JVST_OP_BR, "loop_2"),
 
             oplabel, "valid_12",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             oplabel, "invalid_8_10",
-            newop_invalid(&A, 8),
+            newop_return(&A, 8),
 
             NULL
           ),
@@ -4104,7 +4104,7 @@ void test_op_dependencies(void)
             newop_br(&A, JVST_OP_CBT, "M_13"),
 
             oplabel, "invalid_9_14",
-            newop_invalid(&A, 9),
+            newop_return(&A, 9),
 
             oplabel, "M_7",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -4132,10 +4132,10 @@ void test_op_dependencies(void)
             newop_br(&A, JVST_OP_CBT, "valid_17"),
 
             oplabel, "invalid_6_19",
-            newop_invalid(&A, 6),
+            newop_return(&A, 6),
 
             oplabel, "valid_17",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             NULL
           ),
@@ -4415,7 +4415,7 @@ void test_op_dependencies(void)
             newop_instr(&A, JVST_OP_CONSUME),
 
             oplabel, "valid_5",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             oplabel, "true_2",
             newop_instr2(&A, JVST_OP_SPLITV, oparg_lit(0), oparg_slot(0)),
@@ -4431,7 +4431,7 @@ void test_op_dependencies(void)
             newop_br(&A, JVST_OP_CBT, "and_true_8"),
 
             oplabel, "invalid_7_7",
-            newop_invalid(&A, 7),
+            newop_return(&A, 7),
 
             oplabel, "and_true_8",
             newop_load(&A, JVST_OP_MOVE, oparg_slot(3), oparg_slot(0)),
@@ -4447,7 +4447,7 @@ void test_op_dependencies(void)
             newop_br(&A, JVST_OP_BR, "invalid_7_7"),
 
             oplabel, "invalid_1_14",
-            newop_invalid(&A, 1),
+            newop_return(&A, 1),
 
             NULL
           ),
@@ -4470,17 +4470,17 @@ void test_op_dependencies(void)
             newop_br(&A, JVST_OP_CBT, "invalid_8_10"),
 
             oplabel, "invalid_9_11",
-            newop_invalid(&A, 9),
+            newop_return(&A, 9),
 
             oplabel, "M_7",
             newop_instr(&A, JVST_OP_CONSUME),
             newop_br(&A, JVST_OP_BR, "loop_2"),
 
             oplabel, "valid_12",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             oplabel, "invalid_8_10",
-            newop_invalid(&A, 8),
+            newop_return(&A, 8),
 
             NULL
           ),
@@ -4512,7 +4512,7 @@ void test_op_dependencies(void)
             newop_br(&A, JVST_OP_CBT, "M_13"),
 
             oplabel, "invalid_9_14",
-            newop_invalid(&A, 9),
+            newop_return(&A, 9),
 
             oplabel, "M_7",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -4540,10 +4540,10 @@ void test_op_dependencies(void)
             newop_br(&A, JVST_OP_CBT, "valid_17"),
 
             oplabel, "invalid_6_19",
-            newop_invalid(&A, 6),
+            newop_return(&A, 6),
 
             oplabel, "valid_17",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             NULL
           ),
@@ -4567,17 +4567,17 @@ void test_op_dependencies(void)
             newop_br(&A, JVST_OP_CBT, "invalid_8_10"),
 
             oplabel, "invalid_9_11",
-            newop_invalid(&A, 9),
+            newop_return(&A, 9),
 
             oplabel, "M_7",
             newop_instr(&A, JVST_OP_CONSUME),
             newop_br(&A, JVST_OP_BR, "loop_2"),
 
             oplabel, "valid_12",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             oplabel, "invalid_8_10",
-            newop_invalid(&A, 8),
+            newop_return(&A, 8),
 
             NULL
           ),
@@ -4605,7 +4605,7 @@ void test_op_dependencies(void)
             newop_br(&A, JVST_OP_CBT, "M_11"),
 
             oplabel, "invalid_9_12",
-            newop_invalid(&A, 9),
+            newop_return(&A, 9),
 
             oplabel, "M_7",
             newop_instr(&A, JVST_OP_CONSUME),
@@ -4628,10 +4628,10 @@ void test_op_dependencies(void)
             newop_br(&A, JVST_OP_CBT, "valid_15"),
 
             oplabel, "invalid_6_17",
-            newop_invalid(&A, 6),
+            newop_return(&A, 6),
 
             oplabel, "valid_15",
-            newop_instr(&A, JVST_OP_VALID),
+            newop_return(&A, 0),
 
             NULL
           ),

--- a/tests/unit/validate_testing.c
+++ b/tests/unit/validate_testing.c
@@ -2405,8 +2405,7 @@ newop_cmp(struct arena_info *A, enum jvst_vm_op op,
 	case JVST_OP_INCR:
 	case JVST_OP_BSET:
 	case JVST_OP_BAND:
-	case JVST_OP_VALID:
-	case JVST_OP_INVALID:
+	case JVST_OP_RETURN:
 	case JVST_OP_MOVE:
 		fprintf(stderr, "%s:%d (%s) OP %s is not a comparison\n",
 			__FILE__, __LINE__, __func__, jvst_op_name(op));
@@ -2538,8 +2537,7 @@ newop_load(struct arena_info *A, enum jvst_vm_op op,
 	case JVST_OP_INCR:
 	case JVST_OP_BSET:
 	case JVST_OP_BAND:
-	case JVST_OP_VALID:
-	case JVST_OP_INVALID:
+	case JVST_OP_RETURN:
 		fprintf(stderr, "OP %s is not a load\n",
 			jvst_op_name(op));
 		abort();
@@ -2595,8 +2593,7 @@ newop_br(struct arena_info *A, enum jvst_vm_op op, const char *label)
 	case JVST_OP_INCR:
 	case JVST_OP_BSET:
 	case JVST_OP_BAND:
-	case JVST_OP_VALID:
-	case JVST_OP_INVALID:
+	case JVST_OP_RETURN:
 	case JVST_OP_MOVE:
 		fprintf(stderr, "%s:%d (%s) OP %s is not a branch\n",
 		__FILE__, __LINE__, __func__, jvst_op_name(op));
@@ -2638,10 +2635,10 @@ newop_incr(struct arena_info *A, size_t slot)
 }
 
 struct jvst_op_instr *
-newop_invalid(struct arena_info *A, enum jvst_invalid_code ecode)
+newop_return(struct arena_info *A, enum jvst_invalid_code ecode)
 {
 	struct jvst_op_instr *instr;
-	instr = newop_instr(A, JVST_OP_INVALID);
+	instr = newop_instr(A, JVST_OP_RETURN);
 	instr->args[0].type = JVST_VM_ARG_CONST;
 	instr->args[0].u.index = ecode;
 	return instr;

--- a/tests/unit/validate_testing.h
+++ b/tests/unit/validate_testing.h
@@ -380,7 +380,7 @@ struct jvst_op_instr *
 newop_incr(struct arena_info *A, size_t slot);
 
 struct jvst_op_instr *
-newop_invalid(struct arena_info *A, enum jvst_invalid_code ecode);
+newop_return(struct arena_info *A, enum jvst_invalid_code ecode);
 
 struct jvst_op_instr *
 newop_bitop(struct arena_info *A, enum jvst_vm_op op, int frame_off, int bit);

--- a/tests/unit/validate_testing.h
+++ b/tests/unit/validate_testing.h
@@ -368,7 +368,7 @@ newop_load(struct arena_info *A, enum jvst_vm_op op,
 	struct jvst_op_arg arg1, struct jvst_op_arg arg2);
 
 struct jvst_op_instr *
-newop_br(struct arena_info *A, enum jvst_vm_op op, const char *label);
+newop_br(struct arena_info *A, enum jvst_vm_br_cond brc, const char *label);
 
 struct jvst_op_instr *
 newop_match(struct arena_info *A, int64_t dfa);


### PR DESCRIPTION
1. Combines VALID and INVALID instructions into a single RETURN instruction
2. Changes how numbers are compared: replaces many specific comparison instructions with two (ICMP/FCMP), replaces three branch instructions with a single branch instruction, and adds a comparison field to the branch instruction.

Should close https://github.com/katef/jvst/issues/36 and https://github.com/katef/jvst/issues/35